### PR TITLE
MANTA-4840 fix build with gcc7

### DIFF
--- a/src/core/ngx_murmurhash.c
+++ b/src/core/ngx_murmurhash.c
@@ -1,6 +1,7 @@
 
 /*
  * Copyright (C) Austin Appleby
+ * Copyright 2019 Joyent, Inc.
  */
 
 
@@ -35,8 +36,10 @@ ngx_murmur_hash2(u_char *data, size_t len)
     switch (len) {
     case 3:
         h ^= data[2] << 16;
+        /* fall through */
     case 2:
         h ^= data[1] << 8;
+        /* fall through */
     case 1:
         h ^= data[0];
         h *= 0x5bd1e995;

--- a/src/http/modules/mpu/ngx_http_mpu_commit_module.c
+++ b/src/http/modules/mpu/ngx_http_mpu_commit_module.c
@@ -22,7 +22,7 @@
  */
 
 /*
- * Copyright 2017 Joyent, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 /*
@@ -485,7 +485,7 @@ mpu_readin_request(mpu_request_t *mpcr, nvlist_t **nvl)
 	buf[0] = '\0';
 	off = 0;
 	do {
-		size_t toread = MIN(st.st_size, mpcr->mpcr_buflen);
+		size_t toread = MIN((size_t)st.st_size, (size_t)mpcr->mpcr_buflen);
 
 		/*
 		 * Use pread(2), we don't know where nginx has left off reading

--- a/src/http/ngx_http_parse.c
+++ b/src/http/ngx_http_parse.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (C) Igor Sysoev
  * Copyright (C) Nginx, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 
@@ -1382,6 +1383,7 @@ ngx_http_parse_complex_uri(ngx_http_request_t *r, ngx_uint_t merge_slashes)
                 goto done;
             case '+':
                 r->plus_in_uri = 1;
+                /* fall through */
             default:
                 state = sw_usual;
                 *u++ = ch;
@@ -1423,6 +1425,7 @@ ngx_http_parse_complex_uri(ngx_http_request_t *r, ngx_uint_t merge_slashes)
                 goto done;
             case '+':
                 r->plus_in_uri = 1;
+                /* fall through */
             default:
                 state = sw_usual;
                 *u++ = ch;
@@ -1470,6 +1473,7 @@ ngx_http_parse_complex_uri(ngx_http_request_t *r, ngx_uint_t merge_slashes)
                 goto done;
             case '+':
                 r->plus_in_uri = 1;
+                /* fall through */
             default:
                 state = sw_usual;
                 *u++ = ch;

--- a/src/os/unix/ngx_process.c
+++ b/src/os/unix/ngx_process.c
@@ -2,6 +2,7 @@
 /*
  * Copyright (C) Igor Sysoev
  * Copyright (C) Nginx, Inc.
+ * Copyright 2019 Joyent, Inc.
  */
 
 
@@ -405,6 +406,7 @@ ngx_signal_handler(int signo)
                 break;
             }
             ngx_debug_quit = 1;
+            /* fall through */
         case ngx_signal_value(NGX_SHUTDOWN_SIGNAL):
             ngx_quit = 1;
             action = ", shutting down";


### PR DESCRIPTION
This applies the patch from https://trac.nginx.org/nginx/ticket/1259 and fixes a casting issue to make nginx build with gcc7. Tested on 19.1.0 build image.