### PR TITLE
Revert "MANTA-4949 Remove MPU from Mako (#2)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,34 @@ features:
 
 * Return the calculated md5 checksums from the streamed request bodies
 * Ensure that the dav module's renames are properly atomic (fsync)
+* Add support for the multipart upload commit functionality
 
 ## Repository Management
 
 This repository is downstream of the [github nginx
 mirror](https://github.com/nginx/nginx).
 
-To better understand and maintain our differences from nginx, we try to manage
-branches in a specific fashion. First and foremost, all branches from the
-upstream nginx repository are mirrored here.
+To better understand and maintain our differences from nginx, we try to
+manage branches and tags in a specific fashion. First and foremost, all
+branches and tags from the upstream nginx repository are mirrored here.
 
 Anything that is Joyent-specific begins with a `joyent/` prefix. The one
-exception to this is the old `mako` branch which represents the original changes
-we made against nginx back in 2012 and 2013.
+exception to this is the old `mako` branch which represents the original
+changes we made against nginx back in 2012 and 2013.
 
-Branches with Joyent modifications are named `joyent/<version>-mantav<version>`,
-such as `joyent/1.10.2-mantav2`.  This is a branch that starts from the nginx
-`release-1.10.2` tag and is intended for use by the mantav2 versions of Manta
-components.
-
-These branches will have all of our patches rebased on top of them. Currently,
-this repository is consumed by `mako`, which contains a git submodule for this
-repository. That submodule will point to a commit in this repository in the
-appropriate manta version branch.
+Branches with Joyent modifications are named `joyent/<version>`, such as
+`joyent/1.10.2`. This is a branch that starts from the nginx
+`release-1.10.2` tag. These branches will have all of our patches
+rebased on top of them. Currently, this repository is consumed by
+`mako`, which contains a git submodule for this repository. That
+submodule will point to a tag in this repository that uses the form
+`joyent/v<version>j<branch release num>`. The first release as described
+above would be: `joyent/v1.10.2j1`. If we need to cut another release
+from this branch, we would tag it `joyent/v1.10.2j2` and continue to
+increment the number after the `j`. Note we use the `j` instead of `r`
+which would more traditionally be used to indicate a revision.  We use
+`j` in case nginx for some reason wants to use it in its version strings
+for whatever reason.
 
 When it comes time to update to a newer version of nginx, we would take
 the following steps:
@@ -41,11 +46,25 @@ the following steps:
   all of our branches and tags.
 * Identify the release tag that corresponds to the point release. For
   this example, we'll say that's `release-1.12.3`.
-* Create a new branch named `joyent/<version>-mantavX` from the tag. In this
-  case we would name the branch `joyent/1.12.3-mantav2`.
+* Create a new branch named `joyent/<version>` from the tag. In this
+  case we would name the branch `joyent/1.12.3`.
 * Rebase all of our patches on to that new branch, removing any patches
   that are no longer necessary.
 * Test the new nginx binary.
 * Review and Commit all relevant changes.
+* Create a new tag `joyent/v1.12.3j1`.
 * Update the [manta-mako](https://github.com/joyent/manta-mako)
-  submodule to point to the new commit.
+  submodule to point to the new tag.
+
+## MPU Module Dependencies
+
+The MPU module contains several dependencies which can be found in the
+directory `rc/http/modules/mpu/deps`. Changes should not be made locally
+(beyond adjusting header include paths), but rather they should be
+applied to the upstream repositories.  These modules all come from the
+following external sources:
+
+* The custr files comes from illumos
+* The nvlist-json files comes from illumos
+* The jsonemitter files come from Joyent, but do not have a well defined
+  home

--- a/auto/make
+++ b/auto/make
@@ -13,6 +13,7 @@ mkdir -p $NGX_OBJS/src/core $NGX_OBJS/src/event $NGX_OBJS/src/event/modules \
          $NGX_OBJS/src/stream \
          $NGX_OBJS/src/misc
 
+mkdir -p $NGX_OBJS/src/http/modules/mpu/deps
 
 ngx_objs_dir=$NGX_OBJS$ngx_regex_dirsep
 ngx_use_pch=`echo $NGX_USE_PCH | sed -e "s/\//$ngx_regex_dirsep/g"`

--- a/auto/modules
+++ b/auto/modules
@@ -126,6 +126,7 @@ fi
 #     ngx_http_static_module
 #     ngx_http_gzip_static_module
 #     ngx_http_dav_module
+#     ngx_http_mpu_commit_module
 #     ngx_http_autoindex_module
 #     ngx_http_index_module
 #     ngx_http_random_index_module
@@ -162,6 +163,7 @@ HTTP_FILTER_MODULES=
 ngx_module_order="ngx_http_static_module \
                   ngx_http_gzip_static_module \
                   ngx_http_dav_module \
+                  ngx_http_mpu_commit_module \
                   ngx_http_autoindex_module \
                   ngx_http_index_module \
                   ngx_http_random_index_module \
@@ -475,6 +477,13 @@ if [ $HTTP_DAV = YES ]; then
     ngx_module_link=$HTTP_DAV
 
     . auto/module
+fi
+
+if [ $HTTP_MPU_COMMIT = YES ]; then
+    have=NGX_HTTP_MPU_COMMIT . auto/have
+    HTTP_MODULES="$HTTP_MODULES $HTTP_MPU_COMMIT_MODULE"
+    HTTP_SRCS="$HTTP_SRCS $HTTP_MPU_COMMIT_SRCS"
+    CORE_LIBS="$CORE_LIBS -lnvpair"
 fi
 
 if [ $HTTP_AUTOINDEX = YES ]; then

--- a/auto/options
+++ b/auto/options
@@ -68,6 +68,7 @@ HTTP_IMAGE_FILTER=NO
 HTTP_SUB=NO
 HTTP_ADDITION=NO
 HTTP_DAV=NO
+HTTP_MPU_COMMIT=NO
 HTTP_ACCESS=YES
 HTTP_AUTH_BASIC=YES
 HTTP_AUTH_REQUEST=NO
@@ -231,6 +232,7 @@ do
                                          HTTP_GEOIP=DYNAMIC         ;;
         --with-http_sub_module)          HTTP_SUB=YES               ;;
         --with-http_dav_module)          HTTP_DAV=YES               ;;
+        --with-http_mpu_commit)          HTTP_MPU_COMMIT=YES        ;;
         --with-http_flv_module)          HTTP_FLV=YES               ;;
         --with-http_mp4_module)          HTTP_MP4=YES               ;;
         --with-http_gunzip_module)       HTTP_GUNZIP=YES            ;;

--- a/auto/sources
+++ b/auto/sources
@@ -249,5 +249,11 @@ WIN32_SRCS="$CORE_SRCS $EVENT_SRCS \
 NGX_WIN32_ICONS="src/os/win32/nginx.ico"
 NGX_WIN32_RC="src/os/win32/nginx.rc"
 
+HTTP_MPU_COMMIT_MODULE=ngx_http_mpu_commit_module
+HTTP_MPU_COMMIT_SRCS="src/http/modules/mpu/ngx_http_mpu_commit_module.c \
+	src/http/modules/mpu/deps/custr.c \
+	src/http/modules/mpu/deps/jsonemitter.c \
+	src/http/modules/mpu/deps/json-nvlist.c"
+
 
 HTTP_FILE_CACHE_SRCS=src/http/ngx_http_file_cache.c

--- a/src/http/modules/mpu/deps/custr.c
+++ b/src/http/modules/mpu/deps/custr.c
@@ -1,0 +1,212 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * This file was lifted from "usr/src/lib/libcmdutils/common/custr.c" in
+ * illumos.  The custr*() suite of string processing routines was only
+ * introduced in December 2014.  In order to avoid introducing a build machine
+ * flag day, we ship a private copy here.
+ *
+ * This copy should be replaced with the use of libcmdutils in the future.
+ */
+
+/*
+ * String utility functions with dynamic memory management.
+ */
+
+/*
+ * Copyright 2015 Joyent, Inc.
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include <err.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <sys/debug.h>
+
+#include "custr.h"
+
+typedef enum {
+	CUSTR_FIXEDBUF	= 0x01
+} custr_flags_t;
+
+struct custr {
+	size_t cus_strlen;
+	size_t cus_datalen;
+	char *cus_data;
+	custr_flags_t cus_flags;
+};
+
+#define	STRING_CHUNK_SIZE	64
+
+void
+custr_reset(custr_t *cus)
+{
+	if (cus->cus_data == NULL)
+		return;
+
+	cus->cus_strlen = 0;
+	cus->cus_data[0] = '\0';
+}
+
+size_t
+custr_len(custr_t *cus)
+{
+	return (cus->cus_strlen);
+}
+
+const char *
+custr_cstr(custr_t *cus)
+{
+	if (cus->cus_data == NULL) {
+		VERIFY(cus->cus_strlen == 0);
+		VERIFY(cus->cus_datalen == 0);
+
+		/*
+		 * This function should never return NULL.  If no buffer has
+		 * been allocated, return a pointer to a zero-length string.
+		 */
+		return ("");
+	}
+	return (cus->cus_data);
+}
+
+static int
+custr_append_vprintf(custr_t *cus, const char *fmt, va_list ap)
+{
+	int len = vsnprintf(NULL, 0, fmt, ap);
+	size_t chunksz = STRING_CHUNK_SIZE;
+
+	if (len < 0) {
+		return (-1);
+	}
+
+	while (chunksz < (size_t)len) {
+		chunksz *= 2;
+	}
+
+	if (len + cus->cus_strlen + 1 >= cus->cus_datalen) {
+		char *new_data;
+		size_t new_datalen = cus->cus_datalen + chunksz;
+
+		if (cus->cus_flags & CUSTR_FIXEDBUF) {
+			errno = EOVERFLOW;
+			return (-1);
+		}
+
+		/*
+		 * Allocate replacement memory:
+		 */
+		if ((new_data = malloc(new_datalen)) == NULL) {
+			return (-1);
+		}
+
+		/*
+		 * Copy existing data into replacement memory and free
+		 * the old memory.
+		 */
+		if (cus->cus_data != NULL) {
+			(void) memcpy(new_data, cus->cus_data,
+			    cus->cus_strlen + 1);
+			free(cus->cus_data);
+		}
+
+		/*
+		 * Swap in the replacement buffer:
+		 */
+		cus->cus_data = new_data;
+		cus->cus_datalen = new_datalen;
+	}
+	/*
+	 * Append new string to existing string:
+	 */
+	len = vsnprintf(cus->cus_data + cus->cus_strlen,
+	    (uintptr_t)cus->cus_datalen - (uintptr_t)cus->cus_strlen, fmt, ap);
+	if (len == -1)
+		return (len);
+	cus->cus_strlen += len;
+
+	return (0);
+}
+
+int
+custr_appendc(custr_t *cus, char newc)
+{
+	return (custr_append_printf(cus, "%c", newc));
+}
+
+int
+custr_append_printf(custr_t *cus, const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+	ret = custr_append_vprintf(cus, fmt, ap);
+	va_end(ap);
+
+	return (ret);
+}
+
+int
+custr_append(custr_t *cus, const char *name)
+{
+	return (custr_append_printf(cus, "%s", name));
+}
+
+int
+custr_alloc(custr_t **cus)
+{
+	custr_t *t;
+
+	if ((t = calloc(1, sizeof (*t))) == NULL) {
+		*cus = NULL;
+		return (-1);
+	}
+
+	*cus = t;
+	return (0);
+}
+
+int
+custr_alloc_buf(custr_t **cus, void *buf, size_t buflen)
+{
+	int ret;
+
+	if (buflen == 0 || buf == NULL) {
+		errno = EINVAL;
+		return (-1);
+	}
+
+	if ((ret = custr_alloc(cus)) != 0)
+		return (ret);
+
+	(*cus)->cus_data = buf;
+	(*cus)->cus_datalen = buflen;
+	(*cus)->cus_strlen = 0;
+	(*cus)->cus_flags = CUSTR_FIXEDBUF;
+	(*cus)->cus_data[0] = '\0';
+
+	return (0);
+}
+
+void
+custr_free(custr_t *cus)
+{
+	if (cus == NULL)
+		return;
+
+	if ((cus->cus_flags & CUSTR_FIXEDBUF) == 0)
+		free(cus->cus_data);
+	free(cus);
+}

--- a/src/http/modules/mpu/deps/custr.h
+++ b/src/http/modules/mpu/deps/custr.h
@@ -1,0 +1,80 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2015 Joyent, Inc.
+ */
+
+#ifndef _CUSTR_H
+#define	_CUSTR_H
+
+/*
+ * Private copy of custr*() utilities from libcmdutils.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct custr custr_t;
+
+/*
+ * Allocate and free a "custr_t" dynamic string object.  Returns 0 on success
+ * and -1 otherwise.
+ */
+extern int custr_alloc(custr_t **);
+extern void custr_free(custr_t *);
+
+/*
+ * Allocate a "custr_t" dynamic string object that operates on a fixed external
+ * buffer.
+ */
+extern int custr_alloc_buf(custr_t **, void *, size_t);
+
+/*
+ * Append a single character, or a NUL-terminated string of characters, to a
+ * dynamic string.  Returns 0 on success and -1 otherwise.  The dynamic string
+ * will be unmodified if the function returns -1.
+ */
+extern int custr_appendc(custr_t *, char);
+extern int custr_append(custr_t *, const char *);
+
+/*
+ * Append a format string and arguments as though the contents were being parsed
+ * through snprintf. Returns 0 on success and -1 otherwise.  The dynamic string
+ * will be unmodified if the function returns -1.
+ */
+extern int custr_append_printf(custr_t *, const char *, ...);
+
+/*
+ * Determine the length in bytes, not including the NUL terminator, of the
+ * dynamic string.
+ */
+extern size_t custr_len(custr_t *);
+
+/*
+ * Clear the contents of a dynamic string.  Does not free the underlying
+ * memory.
+ */
+extern void custr_reset(custr_t *);
+
+/*
+ * Retrieve a const pointer to a NUL-terminated string version of the contents
+ * of the dynamic string.  Storage for this string should not be freed, and
+ * the pointer will be invalidated by any mutations to the dynamic string.
+ */
+extern const char *custr_cstr(custr_t *str);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif /* _CUSTR_H */

--- a/src/http/modules/mpu/deps/json-nvlist.c
+++ b/src/http/modules/mpu/deps/json-nvlist.c
@@ -1,0 +1,940 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2018 Joyent, Inc.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <strings.h>
+#include <errno.h>
+#include <libnvpair.h>
+
+#include "json-nvlist.h"
+
+typedef enum json_type {
+	JSON_TYPE_NOTHING = 0,
+	JSON_TYPE_STRING = 1,
+	JSON_TYPE_INTEGER,
+	JSON_TYPE_DOUBLE,
+	JSON_TYPE_BOOLEAN,
+	JSON_TYPE_NULL,
+	JSON_TYPE_OBJECT,
+	JSON_TYPE_ARRAY
+} json_type_t;
+
+typedef enum parse_state {
+	PARSE_ERROR = -1,
+	PARSE_DONE = 0,
+	PARSE_REST,
+	PARSE_OBJECT,
+	PARSE_KEY_STRING,
+	PARSE_COLON,
+	PARSE_STRING,
+	PARSE_OBJECT_COMMA,
+	PARSE_ARRAY,
+	PARSE_BAREWORD,
+	PARSE_NUMBER,
+	PARSE_ARRAY_VALUE,
+	PARSE_ARRAY_COMMA
+} parse_state_t;
+
+#define	JSON_MARKER		".__json_"
+#define	JSON_MARKER_ARRAY	JSON_MARKER "array"
+
+#define	pf_value pf_u.u_ptr
+
+typedef struct parse_frame {
+	parse_state_t pf_ps;
+	nvlist_t *pf_nvl;
+
+	char *pf_key;
+	union {
+		void *u_ptr;
+		int64_t u_i64;
+		double u_double;
+	} pf_u;
+	json_type_t pf_value_type;
+	int pf_array_index;
+
+	struct parse_frame *pf_next;
+} parse_frame_t;
+
+typedef struct state {
+	const char *s_in;
+	unsigned long s_pos;
+	unsigned long s_len;
+
+	parse_frame_t *s_top;
+
+	nvlist_parse_json_flags_t s_flags;
+
+	/*
+	 * This string buffer is used for temporary storage by the
+	 * "collect_*()" family of functions.
+	 */
+	custr_t *s_collect;
+
+	int s_errno;
+	custr_t *s_errstr;
+} state_t;
+
+typedef void (*parse_handler_t)(state_t *);
+
+static void
+movestate(state_t *s, parse_state_t ps)
+{
+	if (s->s_flags & NVJSON_DEBUG) {
+		(void) fprintf(stderr, "nvjson: move state %d -> %d\n",
+		    s->s_top->pf_ps, ps);
+	}
+	s->s_top->pf_ps = ps;
+}
+
+static void
+posterror(state_t *s, int erno, const char *error)
+{
+	/*
+	 * If the caller wants error messages printed to stderr, do that
+	 * first.
+	 */
+	if (s->s_flags & NVJSON_ERRORS_TO_STDERR) {
+		(void) fprintf(stderr, "nvjson error (pos %ld, errno %d): %s\n",
+		    s->s_pos, erno, error);
+	}
+
+	/*
+	 * Try and store the error message for the caller.  This may fail if
+	 * the error was related to memory pressure, and that condition still
+	 * exists.
+	 */
+	s->s_errno = erno;
+	if (s->s_errstr != NULL) {
+		(void) custr_append(s->s_errstr, error);
+	}
+
+	movestate(s, PARSE_ERROR);
+}
+
+static int
+pushstate(state_t *s, parse_state_t ps, parse_state_t retps)
+{
+	parse_frame_t *n;
+
+	if (s->s_flags & NVJSON_DEBUG) {
+		(void) fprintf(stderr, "nvjson: push state %d -> %d (ret %d)\n",
+		    s->s_top->pf_ps, ps, retps);
+	}
+
+	if ((n = calloc(1, sizeof (*n))) == NULL) {
+		posterror(s, errno, "pushstate calloc failure");
+		return (-1);
+	}
+
+	/*
+	 * Store the state we'll return to when popping this
+	 * frame:
+	 */
+	s->s_top->pf_ps = retps;
+
+	/*
+	 * Store the initial state for the new frame, and
+	 * put it on top of the stack:
+	 */
+	n->pf_ps = ps;
+	n->pf_value_type = JSON_TYPE_NOTHING;
+
+	n->pf_next = s->s_top;
+	s->s_top = n;
+
+	return (0);
+}
+
+static char
+popchar(state_t *s)
+{
+	if (s->s_pos > s->s_len) {
+		return (0);
+	}
+	return (s->s_in[s->s_pos++]);
+}
+
+static char
+peekchar(state_t *s)
+{
+	if (s->s_pos > s->s_len) {
+		return (0);
+	}
+	return (s->s_in[s->s_pos]);
+}
+
+static void
+discard_whitespace(state_t *s)
+{
+	while (isspace(peekchar(s))) {
+		(void) popchar(s);
+	}
+}
+
+static char *escape_pairs[] = {
+	"\"\"", "\\\\", "//", "b\b", "f\f", "n\n", "r\r", "t\t", NULL
+};
+
+static char
+collect_string_escape(state_t *s)
+{
+	int i;
+	char c = popchar(s);
+
+	if (c == '\0') {
+		posterror(s, EPROTO, "EOF mid-escape sequence");
+		return (-1);
+	}
+
+	/*
+	 * Handle four-digit Unicode escapes up to and including \u007f.
+	 * Strings that cannot be represented as 7-bit clean ASCII are not
+	 * currently supported.
+	 */
+	if (c == 'u') {
+		int res;
+		int ndigs = 0;
+		char digs[5];
+
+		/*
+		 * Deal with 4-digit unicode escape.
+		 */
+		while (ndigs < 4) {
+			if ((digs[ndigs++] = popchar(s)) == '\0') {
+				posterror(s, EPROTO, "EOF mid-escape "
+				    "sequence");
+				return (-1);
+			}
+		}
+		digs[4] = '\0';
+		if ((res = atoi(digs)) > 127) {
+			posterror(s, EPROTO, "unicode escape above 0x7f");
+			return (-1);
+		}
+
+		if (custr_appendc(s->s_collect, res) != 0) {
+			posterror(s, errno, "custr_appendc failure");
+			return (-1);
+		}
+		return (0);
+	}
+
+	/*
+	 * See if this is a C-style escape character we recognise.
+	 */
+	for (i = 0; escape_pairs[i] != NULL; i++) {
+		char *ep = escape_pairs[i];
+		if (ep[0] == c) {
+			if (custr_appendc(s->s_collect, ep[1]) != 0) {
+				posterror(s, errno, "custr_appendc failure");
+				return (-1);
+			}
+			return (0);
+		}
+	}
+
+	posterror(s, EPROTO, "unrecognised escape sequence");
+	return (-1);
+}
+
+static int
+collect_string(state_t *s)
+{
+	custr_reset(s->s_collect);
+
+	for (;;) {
+		char c;
+
+		switch (c = popchar(s)) {
+		case '"':
+			/*
+			 * Legal End of String.
+			 */
+			return (0);
+
+		case '\0':
+			posterror(s, EPROTO, "EOF mid-string");
+			return (-1);
+
+		case '\\':
+			/*
+			 * Escape Characters and Sequences.
+			 */
+			if (collect_string_escape(s) != 0) {
+				return (-1);
+			}
+			break;
+
+		default:
+			if (custr_appendc(s->s_collect, c) != 0) {
+				posterror(s, errno, "custr_appendc failure");
+				return (-1);
+			}
+			break;
+		}
+	}
+}
+
+static int
+collect_bareword(state_t *s)
+{
+	custr_reset(s->s_collect);
+
+	for (;;) {
+		if (!islower(peekchar(s))) {
+			return (0);
+		}
+
+		if (custr_appendc(s->s_collect, popchar(s)) != 0) {
+			posterror(s, errno, "custr_appendc failure");
+			return (-1);
+		}
+	}
+}
+
+static void
+hdlr_bareword(state_t *s)
+{
+	const char *str;
+
+	if (collect_bareword(s) != 0) {
+		return;
+	}
+
+	str = custr_cstr(s->s_collect);
+	if (strcmp(str, "true") == 0) {
+		s->s_top->pf_value_type = JSON_TYPE_BOOLEAN;
+		s->s_top->pf_value = (void *)B_TRUE;
+	} else if (strcmp(str, "false") == 0) {
+		s->s_top->pf_value_type = JSON_TYPE_BOOLEAN;
+		s->s_top->pf_value = (void *)B_FALSE;
+	} else if (strcmp(str, "null") == 0) {
+		s->s_top->pf_value_type = JSON_TYPE_NULL;
+	} else {
+		posterror(s, EPROTO, "expected 'true', 'false' or 'null'");
+		return;
+	}
+
+	movestate(s, PARSE_DONE);
+}
+
+/* ARGSUSED */
+static int
+collect_number(state_t *s, boolean_t *isint, int64_t *result,
+    double *fresult)
+{
+	boolean_t neg = B_FALSE;
+	int64_t t;
+
+	custr_reset(s->s_collect);
+
+	if (peekchar(s) == '-') {
+		neg = B_TRUE;
+		(void) popchar(s);
+	}
+	/*
+	 * Read the 'int' portion:
+	 */
+	if (!isdigit(peekchar(s))) {
+		posterror(s, EPROTO, "malformed number: expected digit (0-9)");
+		return (-1);
+	}
+	for (;;) {
+		if (!isdigit(peekchar(s))) {
+			break;
+		}
+		if (custr_appendc(s->s_collect, popchar(s)) != 0) {
+			posterror(s, errno, "custr_append failure");
+			return (-1);
+		}
+	}
+	if (peekchar(s) == '.' || peekchar(s) == 'e' || peekchar(s) == 'E') {
+		posterror(s, ENOTSUP, "do not yet support FRACs or EXPs");
+		return (-1);
+	}
+
+	t = atoll(custr_cstr(s->s_collect));
+
+	*isint = B_TRUE;
+	*result = (neg == B_TRUE) ? (-t) : t;
+	return (0);
+}
+
+static void
+hdlr_number(state_t *s)
+{
+	boolean_t isint;
+	int64_t result;
+	double fresult;
+
+	if (collect_number(s, &isint, &result, &fresult) != 0) {
+		return;
+	}
+
+	if (isint == B_TRUE) {
+		s->s_top->pf_u.u_i64 = result;
+		s->s_top->pf_value_type = JSON_TYPE_INTEGER;
+	} else {
+		s->s_top->pf_value = malloc(sizeof (fresult));
+		bcopy(&fresult, s->s_top->pf_value, sizeof (fresult));
+		s->s_top->pf_value_type = JSON_TYPE_DOUBLE;
+	}
+
+	movestate(s, PARSE_DONE);
+}
+
+static void
+hdlr_rest(state_t *s)
+{
+	char c;
+	discard_whitespace(s);
+	c = popchar(s);
+	switch (c) {
+	case '{':
+		movestate(s, PARSE_OBJECT);
+		return;
+
+	case '[':
+		movestate(s, PARSE_ARRAY);
+		return;
+
+	default:
+		posterror(s, EPROTO, "EOF before object or array");
+		return;
+	}
+}
+
+static int
+add_empty_child(state_t *s)
+{
+	/*
+	 * Here, we create an empty nvlist to represent this object
+	 * or array:
+	 */
+	nvlist_t *empty;
+	if (nvlist_alloc(&empty, NV_UNIQUE_NAME, 0) != 0) {
+		posterror(s, errno, "nvlist_alloc failure");
+		return (-1);
+	}
+	if (s->s_top->pf_next != NULL) {
+		/*
+		 * If we're a child of the frame above, we store ourselves in
+		 * that frame's nvlist:
+		 */
+		nvlist_t *nvl = s->s_top->pf_next->pf_nvl;
+		char *key = s->s_top->pf_next->pf_key;
+
+		if (nvlist_add_nvlist(nvl, key, empty) != 0) {
+			posterror(s, errno, "nvlist_add_nvlist failure");
+			nvlist_free(empty);
+			return (-1);
+		}
+		nvlist_free(empty);
+		if (nvlist_lookup_nvlist(nvl, key, &empty) != 0) {
+			posterror(s, errno, "nvlist_lookup_nvlist failure");
+			return (-1);
+		}
+	}
+	s->s_top->pf_nvl = empty;
+	return (0);
+}
+
+static int
+decorate_array(state_t *s)
+{
+	int idx = s->s_top->pf_array_index;
+	/*
+	 * When we are done creating an array, we store a 'length'
+	 * property on it, as well as an internal-use marker value.
+	 */
+	if (nvlist_add_boolean(s->s_top->pf_nvl, JSON_MARKER_ARRAY) != 0 ||
+	    nvlist_add_uint32(s->s_top->pf_nvl, "length", idx) != 0) {
+		posterror(s, errno, "nvlist_add failure");
+		return (-1);
+	}
+
+	return (0);
+}
+
+static void
+hdlr_array(state_t *s)
+{
+	s->s_top->pf_value_type = JSON_TYPE_ARRAY;
+
+	if (add_empty_child(s) != 0) {
+		return;
+	}
+
+	discard_whitespace(s);
+
+	switch (peekchar(s)) {
+	case ']':
+		(void) popchar(s);
+
+		if (decorate_array(s) != 0) {
+			return;
+		}
+
+		movestate(s, PARSE_DONE);
+		return;
+
+	default:
+		movestate(s, PARSE_ARRAY_VALUE);
+		return;
+	}
+}
+
+static void
+hdlr_array_comma(state_t *s)
+{
+	discard_whitespace(s);
+
+	switch (popchar(s)) {
+	case ']':
+		if (decorate_array(s) != 0) {
+			return;
+		}
+
+		movestate(s, PARSE_DONE);
+		return;
+	case ',':
+		movestate(s, PARSE_ARRAY_VALUE);
+		return;
+	default:
+		posterror(s, EPROTO, "expected ',' or ']'");
+		return;
+	}
+}
+
+static void
+hdlr_array_value(state_t *s)
+{
+	char c;
+
+	/*
+	 * Generate keyname from the next array index:
+	 */
+	if (s->s_top->pf_key != NULL) {
+		(void) fprintf(stderr, "pf_key not null! was %s\n",
+		    s->s_top->pf_key);
+		abort();
+	}
+
+	if (asprintf(&s->s_top->pf_key, "%d", s->s_top->pf_array_index++) < 0) {
+		posterror(s, errno, "asprintf failure");
+		return;
+	}
+
+	discard_whitespace(s);
+
+	/*
+	 * Select which type handler we need for the next value:
+	 */
+	switch (c = peekchar(s)) {
+	case '"':
+		(void) popchar(s);
+		(void) pushstate(s, PARSE_STRING, PARSE_ARRAY_COMMA);
+		return;
+
+	case '{':
+		(void) popchar(s);
+		(void) pushstate(s, PARSE_OBJECT, PARSE_ARRAY_COMMA);
+		return;
+
+	case '[':
+		(void) popchar(s);
+		(void) pushstate(s, PARSE_ARRAY, PARSE_ARRAY_COMMA);
+		return;
+
+	default:
+		if (islower(c)) {
+			(void) pushstate(s, PARSE_BAREWORD,
+			    PARSE_ARRAY_COMMA);
+			return;
+		} else if (c == '-' || isdigit(c)) {
+			(void) pushstate(s, PARSE_NUMBER, PARSE_ARRAY_COMMA);
+			return;
+		} else {
+			posterror(s, EPROTO, "unexpected character at start "
+			    "of value");
+			return;
+		}
+	}
+}
+
+static void
+hdlr_object(state_t *s)
+{
+	s->s_top->pf_value_type = JSON_TYPE_OBJECT;
+
+	if (add_empty_child(s) != 0) {
+		return;
+	}
+
+	discard_whitespace(s);
+
+	switch (popchar(s)) {
+	case '}':
+		movestate(s, PARSE_DONE);
+		return;
+
+	case '"':
+		movestate(s, PARSE_KEY_STRING);
+		return;
+
+	default:
+		posterror(s, EPROTO, "expected key or '}'");
+		return;
+	}
+}
+
+static void
+hdlr_key_string(state_t *s)
+{
+	if (collect_string(s) != 0) {
+		return;
+	}
+
+	/*
+	 * Record the key name of the next value.
+	 */
+	if ((s->s_top->pf_key = strdup(custr_cstr(s->s_collect))) == NULL) {
+		posterror(s, errno, "strdup failure");
+		return;
+	}
+
+	movestate(s, PARSE_COLON);
+}
+
+static void
+hdlr_colon(state_t *s)
+{
+	char c;
+	discard_whitespace(s);
+
+	if ((c = popchar(s)) != ':') {
+		posterror(s, EPROTO, "expected ':'");
+		return;
+	}
+
+	discard_whitespace(s);
+
+	/*
+	 * Select which type handler we need for the value after the colon:
+	 */
+	switch (c = peekchar(s)) {
+	case '"':
+		(void) popchar(s);
+		(void) pushstate(s, PARSE_STRING, PARSE_OBJECT_COMMA);
+		return;
+
+	case '{':
+		(void) popchar(s);
+		(void) pushstate(s, PARSE_OBJECT, PARSE_OBJECT_COMMA);
+		return;
+
+	case '[':
+		(void) popchar(s);
+		(void) pushstate(s, PARSE_ARRAY, PARSE_OBJECT_COMMA);
+		return;
+
+	default:
+		if (islower(c)) {
+			(void) pushstate(s, PARSE_BAREWORD, PARSE_OBJECT_COMMA);
+			return;
+		} else if (c == '-' || isdigit(c)) {
+			(void) pushstate(s, PARSE_NUMBER, PARSE_OBJECT_COMMA);
+			return;
+		} else {
+			(void) posterror(s, EPROTO, "unexpected character at "
+			    "start of value");
+			return;
+		}
+	}
+}
+
+static void
+hdlr_object_comma(state_t *s)
+{
+	discard_whitespace(s);
+
+	switch (popchar(s)) {
+	case '}':
+		movestate(s, PARSE_DONE);
+		return;
+
+	case ',':
+		discard_whitespace(s);
+		if (popchar(s) != '"') {
+			posterror(s, EPROTO, "expected '\"'");
+			return;
+		}
+		movestate(s, PARSE_KEY_STRING);
+		return;
+
+	default:
+		posterror(s, EPROTO, "expected ',' or '}'");
+		return;
+	}
+}
+
+static void
+hdlr_string(state_t *s)
+{
+	if (collect_string(s) != 0) {
+		return;
+	}
+
+	s->s_top->pf_value_type = JSON_TYPE_STRING;
+	if ((s->s_top->pf_value = strdup(custr_cstr(s->s_collect))) == NULL) {
+		posterror(s, errno, "strdup failure");
+		return;
+	}
+
+	movestate(s, PARSE_DONE);
+}
+
+static int
+store_value(state_t *s)
+{
+	nvlist_t *targ = s->s_top->pf_next->pf_nvl;
+	char *key = s->s_top->pf_next->pf_key;
+	json_type_t type = s->s_top->pf_value_type;
+	int ret = 0;
+
+	switch (type) {
+	case JSON_TYPE_STRING:
+		if (nvlist_add_string(targ, key, s->s_top->pf_value) != 0) {
+			posterror(s, errno, "nvlist_add_string failure");
+			ret = -1;
+		}
+		free(s->s_top->pf_value);
+		break;
+
+	case JSON_TYPE_BOOLEAN:
+		if (nvlist_add_boolean_value(targ, key,
+		    (boolean_t)s->s_top->pf_value) != 0) {
+			posterror(s, errno, "nvlist_add_boolean_value "
+			    "failure");
+			ret = -1;
+		}
+		break;
+
+	case JSON_TYPE_NULL:
+		if (nvlist_add_boolean(targ, key) != 0) {
+			posterror(s, errno, "nvlist_add_boolean failure");
+			ret = -1;
+		}
+		break;
+
+	case JSON_TYPE_INTEGER:
+		if (nvlist_add_int64(targ, key, s->s_top->pf_u.u_i64) != 0) {
+			posterror(s, errno, "nvlist_add_int32 failure");
+			ret = -1;
+		}
+		break;
+
+	case JSON_TYPE_ARRAY:
+	case JSON_TYPE_OBJECT:
+		/*
+		 * Objects and arrays are already 'stored' in their target
+		 * nvlist on creation. See: hdlr_object, hdlr_array.
+		 */
+		break;
+
+	default:
+		(void) fprintf(stderr, "ERROR: could not store unknown "
+		    "type %d\n", type);
+		abort();
+	}
+
+	s->s_top->pf_value = NULL;
+	free(s->s_top->pf_next->pf_key);
+	s->s_top->pf_next->pf_key = NULL;
+	return (ret);
+}
+
+static parse_frame_t *
+parse_frame_free(parse_frame_t *pf, boolean_t free_nvl)
+{
+	parse_frame_t *next = pf->pf_next;
+	if (pf->pf_key != NULL) {
+		free(pf->pf_key);
+	}
+	if (pf->pf_value != NULL) {
+		abort();
+	}
+	if (free_nvl && pf->pf_nvl != NULL) {
+		nvlist_free(pf->pf_nvl);
+	}
+	free(pf);
+	return (next);
+}
+
+static parse_handler_t hdlrs[] = {
+	NULL,				/* PARSE_DONE */
+	hdlr_rest,			/* PARSE_REST */
+	hdlr_object,			/* PARSE_OBJECT */
+	hdlr_key_string,		/* PARSE_KEY_STRING */
+	hdlr_colon,			/* PARSE_COLON */
+	hdlr_string,			/* PARSE_STRING */
+	hdlr_object_comma,		/* PARSE_OBJECT_COMMA */
+	hdlr_array,			/* PARSE_ARRAY */
+	hdlr_bareword,			/* PARSE_BAREWORD */
+	hdlr_number,			/* PARSE_NUMBER */
+	hdlr_array_value,		/* PARSE_ARRAY_VALUE */
+	hdlr_array_comma		/* PARSE_ARRAY_COMMA */
+};
+#define	NUM_PARSE_HANDLERS	(int)(sizeof (hdlrs) / sizeof (hdlrs[0]))
+
+int
+nvlist_parse_json(const char *buf, size_t buflen, nvlist_t **nvlp,
+    nvlist_parse_json_flags_t flag, nvlist_parse_json_error_t *errout)
+{
+	state_t s;
+
+	/*
+	 * Check for valid flags:
+	 */
+	if ((flag & NVJSON_FORCE_INTEGER) && (flag & NVJSON_FORCE_DOUBLE)) {
+		errno = EINVAL;
+		return (-1);
+	}
+	if ((flag & ~NVJSON_ALL) != 0) {
+		errno = EINVAL;
+		return (-1);
+	}
+
+	/*
+	 * Initialise parsing state structure:
+	 */
+	bzero(&s, sizeof (s));
+	s.s_in = buf;
+	s.s_pos = 0;
+	s.s_len = buflen;
+	s.s_flags = flag;
+
+	/*
+	 * Allocate the collect buffer string.
+	 */
+	if (custr_alloc(&s.s_collect) != 0) {
+		s.s_errno = errno;
+		if (errout != NULL) {
+			(void) snprintf(errout->nje_message,
+			    sizeof (errout->nje_message),
+			    "custr alloc failure: %s",
+			    strerror(errno));
+		}
+		goto out;
+	}
+
+	/*
+	 * If the caller has requested error information, allocate the error
+	 * string now.
+	 */
+	if (errout != NULL) {
+		if (custr_alloc_buf(&s.s_errstr, errout->nje_message,
+		    sizeof (errout->nje_message)) != 0) {
+			s.s_errno = errno;
+			(void) snprintf(errout->nje_message,
+			    sizeof (errout->nje_message),
+			    "custr alloc failure: %s",
+			    strerror(errno));
+			goto out;
+		}
+		custr_reset(s.s_errstr);
+	}
+
+	/*
+	 * Allocate top-most stack frame:
+	 */
+	if ((s.s_top = calloc(1, sizeof (*s.s_top))) == NULL) {
+		s.s_errno = errno;
+		goto out;
+	}
+
+	s.s_top->pf_ps = PARSE_REST;
+	for (;;) {
+		if (s.s_top->pf_ps < 0) {
+			/*
+			 * The parser reported an error.
+			 */
+			goto out;
+		}
+
+		if (s.s_top->pf_ps == PARSE_DONE) {
+			if (s.s_top->pf_next == NULL) {
+				/*
+				 * Last frame, so we're really
+				 * done.
+				 */
+				*nvlp = s.s_top->pf_nvl;
+				goto out;
+			} else {
+				/*
+				 * Otherwise, pop a frame and continue in
+				 * previous state.  Copy out the value we
+				 * created in the old frame:
+				 */
+				if (store_value(&s) != 0) {
+					goto out;
+				}
+
+				/*
+				 * Free old frame:
+				 */
+				s.s_top = parse_frame_free(s.s_top, B_FALSE);
+			}
+		}
+
+		/*
+		 * Dispatch to parser handler routine for this state:
+		 */
+		if (s.s_top->pf_ps >= NUM_PARSE_HANDLERS ||
+		    hdlrs[s.s_top->pf_ps] == NULL) {
+			(void) fprintf(stderr, "no handler for state %d\n",
+			    s.s_top->pf_ps);
+			abort();
+		}
+		hdlrs[s.s_top->pf_ps](&s);
+	}
+
+out:
+	if (errout != NULL) {
+		/*
+		 * Copy out error number and parse position.  The custr_t for
+		 * the error message was backed by the buffer in the error
+		 * object, so no copying is required.
+		 */
+		errout->nje_errno = s.s_errno;
+		errout->nje_pos = s.s_pos;
+	}
+
+	/*
+	 * Free resources:
+	 */
+	while (s.s_top != NULL) {
+		s.s_top = parse_frame_free(s.s_top, s.s_errno == 0 ? B_FALSE :
+		    B_TRUE);
+	}
+	custr_free(s.s_collect);
+	custr_free(s.s_errstr);
+
+	errno = s.s_errno;
+	return (s.s_errno == 0 ? 0 : -1);
+}

--- a/src/http/modules/mpu/deps/json-nvlist.h
+++ b/src/http/modules/mpu/deps/json-nvlist.h
@@ -1,0 +1,52 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2015 Joyent, Inc.
+ */
+
+#ifndef _JSON_NVLIST_H
+#define	_JSON_NVLIST_H
+
+#include <libnvpair.h>
+#include "custr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum nvlist_parse_json_flags {
+	NVJSON_FORCE_INTEGER = 0x01,
+	NVJSON_FORCE_DOUBLE = 0x02,
+	NVJSON_ERRORS_TO_STDERR = 0x04,
+	NVJSON_DEBUG = 0x08
+} nvlist_parse_json_flags_t;
+
+typedef struct nvlist_parse_json_error {
+	int nje_errno;
+	long nje_pos;
+	char nje_message[512];
+} nvlist_parse_json_error_t;
+
+#define	NVJSON_ALL						\
+	(NVJSON_FORCE_INTEGER |					\
+	NVJSON_FORCE_DOUBLE |					\
+	NVJSON_ERRORS_TO_STDERR |				\
+	NVJSON_DEBUG)
+
+extern int nvlist_parse_json(const char *, size_t, nvlist_t **,
+    nvlist_parse_json_flags_t, nvlist_parse_json_error_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* _JSON_NVLIST_H */

--- a/src/http/modules/mpu/deps/jsonemitter.c
+++ b/src/http/modules/mpu/deps/jsonemitter.c
@@ -1,0 +1,690 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2016, Joyent, Inc.
+ */
+
+/*
+ * jsonemitter.c: streaming JSON emitter
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <limits.h>
+
+#include "custr.h"
+
+#include "jsonemitter.h"
+
+/*
+ * JSON_MAX_DEPTH is the maximum supported level of nesting of JSON objects.
+ */
+#define	JSON_MAX_DEPTH	255
+
+typedef enum {
+	JSON_NONE,	/* no object is nested at the current depth */
+	JSON_OBJECT,	/* an object is nested at the current depth */
+	JSON_ARRAY	/* an array is nested at the current depth */
+} json_depthdesc_t;
+
+typedef enum {
+	JSON_BACKING_STDIO,
+	JSON_BACKING_STRING
+} json_backing_t;
+
+/*
+ * A note on depth management: We allow JSON documents to be nested up to
+ * JSON_MAX_DEPTH.  In order to validate output as we emit it, we maintain a
+ * stack indicating which type of object is nested at each level of depth
+ * (either an array or object).  The stack is recorded in "json_parents", with
+ * the top of the stack at "json_parents[json_depth]".  We keep track of the
+ * number of object properties or array elements at each level of depth in
+ * "json_nemitted[json_depth]".
+ */
+struct json_emit {
+	json_backing_t		json_backing;
+
+	FILE			*json_stream;		/* output stream */
+	custr_t			*json_string;		/* output string */
+
+	/* Error conditions. */
+	int			json_error_stdio;	/* last stdio error */
+	int			json_depth_exceeded;	/* max depth exceeded */
+	unsigned int		json_stdio_nskipped;	/* skip due to error */
+	unsigned int		json_nbadfloats;	/* bad FP values */
+
+	/* Nesting state. */
+	unsigned int		json_depth;
+	json_depthdesc_t	json_parents[JSON_MAX_DEPTH + 1];
+	unsigned int		json_nemitted[JSON_MAX_DEPTH + 1];
+
+	custr_t			*json_scratch;
+	int			json_error_scratch;
+
+	int			json_error_utf8;
+	uint8_t			json_error_utf8_byteval;
+};
+
+/*
+ * General-purpose macros.
+ */
+#define	VERIFY(x) ((void)((x) || json_assert_fail(#x, __FILE__, __LINE__)))
+
+/*
+ * Macros used to apply function attributes.
+ */
+#define	JSON_PRINTFLIKE2 __attribute__((__format__(__printf__, 2, 3)))
+
+static char json_panicstr[256];
+static int json_assert_fail(const char *, const char *, int);
+
+static int json_has_error(json_emit_t *);
+
+static void json_emits(json_emit_t *, const char *);
+static void json_emitc(json_emit_t *, char);
+static void json_emit_utf8string(json_emit_t *, const char *);
+static void json_emit_prepare(json_emit_t *, const char *);
+
+static json_depthdesc_t json_nest_kind(json_emit_t *);
+static void json_nest_begin(json_emit_t *, json_depthdesc_t);
+static void json_nest_end(json_emit_t *, json_depthdesc_t);
+
+
+/*
+ * Lifecycle management
+ */
+
+static json_emit_t *
+json_create_common(json_backing_t backing)
+{
+	json_emit_t *jse;
+
+	if ((jse = calloc(1, sizeof (*jse))) == NULL) {
+		return (NULL);
+	}
+
+	if (custr_alloc(&jse->json_scratch) != 0) {
+		free(jse);
+		return (NULL);
+	}
+
+	jse->json_backing = backing;
+
+	return (jse);
+}
+
+json_emit_t *
+json_create_stdio(FILE *outstream)
+{
+	json_emit_t *jse;
+
+	if ((jse = json_create_common(JSON_BACKING_STDIO)) == NULL) {
+		return (NULL);
+	}
+
+	jse->json_stream = outstream;
+
+	return (jse);
+}
+
+json_emit_t *
+json_create_fixed_string(void *buf, size_t buflen)
+{
+	json_emit_t *jse;
+
+	if ((jse = json_create_common(JSON_BACKING_STRING)) == NULL) {
+		return (NULL);
+	}
+
+	if (custr_alloc_buf(&jse->json_string, buf, buflen) != 0) {
+		int e = errno;
+
+		json_fini(jse);
+
+		errno = e;
+		return (NULL);
+	}
+
+	return (jse);
+}
+
+json_emit_t *
+json_create_string(void)
+{
+	json_emit_t *jse;
+
+	if ((jse = json_create_common(JSON_BACKING_STRING)) == NULL) {
+		return (NULL);
+	}
+
+	if (custr_alloc(&jse->json_string) != 0) {
+		int e = errno;
+
+		json_fini(jse);
+
+		errno = e;
+		return (NULL);
+	}
+
+	return (jse);
+}
+
+void
+json_fini(json_emit_t *jse)
+{
+	custr_free(jse->json_string);
+	custr_free(jse->json_scratch);
+	free(jse);
+}
+
+json_error_t
+json_get_error(json_emit_t *jse, char *buf, size_t bufsz)
+{
+	json_error_t kind;
+
+	if (jse->json_error_stdio != 0) {
+		kind = JSE_STDIO;
+		(void) snprintf(buf, bufsz, "%s", strerror(errno));
+	} else if (jse->json_depth_exceeded != 0) {
+		kind = JSE_TOODEEP;
+		(void) snprintf(buf, bufsz, "exceeded maximum supported depth");
+	} else if (jse->json_nbadfloats) {
+		kind = JSE_INVAL;
+		(void) snprintf(buf, bufsz, "unsupported floating point value");
+	} else if (jse->json_error_utf8 != 0) {
+		kind = JSE_INVAL;
+		(void) snprintf(buf, bufsz, "illegal UTF-8 byte (0x%02x)",
+		    (unsigned)jse->json_error_utf8_byteval);
+	} else {
+		kind = JSE_NONE;
+		if (bufsz > 0) {
+			buf[0] = '\0';
+		}
+	}
+
+	return (kind);
+}
+
+/*
+ * Get a C string pointer for the current output buffer.  This pointer is
+ * invalidated as soon as a mutating function is called.
+ */
+const char *
+json_string_cstr(json_emit_t *jse)
+{
+	VERIFY(jse->json_backing == JSON_BACKING_STRING);
+
+	/*
+	 * The output string can only be read if the state machine has
+	 * returned to the rest state, similar to "json_newline()".
+	 */
+	VERIFY(json_nest_kind(jse) == JSON_NONE);
+	VERIFY(jse->json_depth == 0);
+
+	return (custr_cstr(jse->json_string));
+}
+
+size_t
+json_string_len(json_emit_t *jse)
+{
+	VERIFY(jse->json_backing == JSON_BACKING_STRING);
+
+	return (custr_len(jse->json_string));
+}
+
+/*
+ * Clear the accumulated C string.  Can be used after accumulating an
+ * entire JSON object for display, or to write to a file or socket,
+ * to get a clean slate for the next object.
+ */
+void
+json_string_clear(json_emit_t *jse)
+{
+	VERIFY(jse->json_backing == JSON_BACKING_STRING);
+
+	/*
+	 * The output string can only be reset if the state machine has
+	 * returned to the rest state, similar to "json_newline()".
+	 */
+	VERIFY(json_nest_kind(jse) == JSON_NONE);
+	VERIFY(jse->json_depth == 0);
+
+	custr_reset(jse->json_string);
+}
+
+
+/*
+ * Helper functions
+ */
+
+static int
+json_assert_fail(const char *cond, const char *file, int line)
+{
+	int nbytes;
+	nbytes = snprintf(json_panicstr, sizeof (json_panicstr),
+	    "libjsonemitter assertion failed: %s at file %s line %d\n",
+	    cond, file, line);
+	(void) write(STDERR_FILENO, json_panicstr, nbytes);
+	abort();
+}
+
+/*
+ * Returns true if we've seen any error up to this point.
+ */
+static int
+json_has_error(json_emit_t *jse)
+{
+	return (jse->json_error_stdio != 0 || jse->json_depth_exceeded != 0 ||
+	    jse->json_error_scratch != 0 || jse->json_error_utf8 != 0);
+}
+
+static void
+json_emitc(json_emit_t *jse, char c)
+{
+	if (json_has_error(jse)) {
+		jse->json_stdio_nskipped++;
+		return;
+	}
+
+	switch (jse->json_backing) {
+	case JSON_BACKING_STDIO:
+		if (fprintf(jse->json_stream, "%c", c) < 0) {
+			jse->json_error_stdio = errno;
+		}
+		break;
+
+	case JSON_BACKING_STRING:
+		if (custr_appendc(jse->json_string, c) != 0) {
+			jse->json_error_stdio = errno;
+		}
+		break;
+	}
+}
+
+static void
+json_emits(json_emit_t *jse, const char *s)
+{
+	if (json_has_error(jse)) {
+		jse->json_stdio_nskipped++;
+		return;
+	}
+
+	switch (jse->json_backing) {
+	case JSON_BACKING_STDIO:
+		if (fprintf(jse->json_stream, "%s", s) < 0) {
+			jse->json_error_stdio = errno;
+		}
+		break;
+
+	case JSON_BACKING_STRING:
+		if (custr_append(jse->json_string, s) != 0) {
+			jse->json_error_stdio = errno;
+		}
+		break;
+	}
+}
+
+static void
+json_scratch_appendc(json_emit_t *jse, char c)
+{
+	if (json_has_error(jse)) {
+		return;
+	}
+
+	if (custr_appendc(jse->json_scratch, c) != 0) {
+		jse->json_error_scratch = errno;
+		return;
+	}
+}
+
+/*
+ * Emits a UTF-8 (or 7-bit clean ASCII) string, with appropriate translation of
+ * characters that must be escaped in the JSON representation.
+ */
+static void
+json_emit_utf8string(json_emit_t *jse, const char *utf8str)
+{
+	unsigned utf8_more_bytes = 0;
+
+	custr_reset(jse->json_scratch);
+
+	for (const char *cp = utf8str; *cp != '\0'; cp++) {
+		char c = *cp;
+		unsigned char code = c;
+
+		if (utf8_more_bytes > 0) {
+			/*
+			 * We need to collect one or more additional
+			 * bytes to complete this UTF-8 multibyte character.
+			 *
+			 * Every continuation byte matches the bit pattern:
+			 * 	10xxxxxx
+			 */
+			if ((code & 0xC0) != 0x80) {
+				/*
+				 * This is not a valid continuation byte.
+				 */
+				jse->json_error_utf8 = EILSEQ;
+				jse->json_error_utf8_byteval = code;
+				return;
+			}
+
+			json_scratch_appendc(jse, c);
+			utf8_more_bytes--;
+			continue;
+		}
+
+		switch (c) {
+		/*
+		 * Regular characters that must be escaped include the
+		 * string delimiter itself (quotation mark), and the
+		 * escape sequence initiator (reverse solidus):
+		 */
+		case '"':
+			json_scratch_appendc(jse, '\\');
+			json_scratch_appendc(jse, '\"');
+			continue;
+		case '\\':
+			json_scratch_appendc(jse, '\\');
+			json_scratch_appendc(jse, '\\');
+			continue;
+
+		/*
+		 * Control characters with C-style escape sequences:
+		 */
+		case '\b':
+			json_scratch_appendc(jse, '\\');
+			json_scratch_appendc(jse, 'b');
+			continue;
+		case '\f':
+			json_scratch_appendc(jse, '\\');
+			json_scratch_appendc(jse, 'f');
+			continue;
+		case '\n':
+			json_scratch_appendc(jse, '\\');
+			json_scratch_appendc(jse, 'n');
+			continue;
+		case '\r':
+			json_scratch_appendc(jse, '\\');
+			json_scratch_appendc(jse, 'r');
+			continue;
+		case '\t':
+			json_scratch_appendc(jse, '\\');
+			json_scratch_appendc(jse, 't');
+			continue;
+		}
+
+		if (code <= 0x1F) {
+			/*
+			 * This is a control character that was not handled
+			 * above.  Use the four hex digit escape sequence.
+			 */
+			char num[5];
+
+			(void) snprintf(num, 5, "%04x", (unsigned)code);
+
+			json_scratch_appendc(jse, '\\');
+			json_scratch_appendc(jse, 'u');
+			json_scratch_appendc(jse, num[0]);
+			json_scratch_appendc(jse, num[1]);
+			json_scratch_appendc(jse, num[2]);
+			json_scratch_appendc(jse, num[3]);
+			continue;
+		}
+
+		if (code <= 0x7F) {
+			/*
+			 * This is a regular ASCII character, and may be copied
+			 * directly into the output string.
+			 */
+			json_scratch_appendc(jse, c);
+			continue;
+		}
+
+		/*
+		 * Check for a UTF-8 multibyte character.
+		 *
+		 * 	2-byte		110xxxxx
+		 * 	3-byte		1110xxxx
+		 * 	4-byte		11110xxx
+		 */
+		if ((code & 0xE0) == 0xC0) {
+			utf8_more_bytes = 1;
+		} else if ((code & 0xF0) == 0xE0) {
+			utf8_more_bytes = 2;
+		} else if ((code & 0xF8) == 0xF0) {
+			utf8_more_bytes = 3;
+		} else {
+			/*
+			 * This is not a valid UTF-8 character.
+			 */
+			jse->json_error_utf8 = EILSEQ;
+			jse->json_error_utf8_byteval = code;
+			return;
+		}
+
+		/*
+		 * For a valid UTF-8 multibyte character, we must copy all
+		 * related bytes into the output string together.  Copy the
+		 * first now; subsequent bytes will be checked and copied
+		 * because we set "utf8_more_bytes" above.
+		 */
+		json_scratch_appendc(jse, c);
+	}
+
+	if (utf8_more_bytes != 0) {
+		/*
+		 * The string ended in the middle of a character.
+		 */
+		jse->json_error_utf8 = EILSEQ;
+		return;
+	}
+
+	json_emitc(jse, '"');
+	json_emits(jse, custr_cstr(jse->json_scratch));
+	json_emitc(jse, '"');
+}
+
+/*
+ * Each function that emits any kind of object (including the functions that
+ * begin emitting objects and arrays) takes a "label" parameter.  This must be
+ * non-null if and only if we're inside an object.  For convenience, every
+ * function always calls this helper with the label that's provided.  We verify
+ * the argument is consistent with our state, and then we emit the label if we
+ * need to.
+ *
+ * It is illegal to call this function if we've experienced any stdio errors
+ * already.
+ */
+static void
+json_emit_prepare(json_emit_t *jse, const char *label)
+{
+	json_depthdesc_t kind;
+
+	kind = json_nest_kind(jse);
+	if ((kind == JSON_OBJECT || kind == JSON_ARRAY) &&
+	    jse->json_nemitted[jse->json_depth] > 0) {
+		json_emitc(jse, ',');
+	}
+
+	if (label == NULL) {
+		VERIFY(kind != JSON_OBJECT);
+		return;
+	}
+
+	VERIFY(kind == JSON_OBJECT);
+	json_emit_utf8string(jse, label);
+	json_emitc(jse, ':');
+}
+
+static void
+json_emit_finish(json_emit_t *jse)
+{
+	jse->json_nemitted[jse->json_depth]++;
+}
+
+static json_depthdesc_t
+json_nest_kind(json_emit_t *jse)
+{
+	json_depthdesc_t kind;
+	VERIFY(jse->json_depth <= JSON_MAX_DEPTH);
+	kind = jse->json_parents[jse->json_depth];
+	VERIFY(jse->json_depth == 0 ||
+	    kind == JSON_OBJECT || kind == JSON_ARRAY);
+	return (kind);
+}
+
+static void
+json_nest_begin(json_emit_t *jse, json_depthdesc_t kind)
+{
+	VERIFY(kind == JSON_OBJECT || kind == JSON_ARRAY);
+
+	if (json_has_error(jse)) {
+		return;
+	}
+
+	if (jse->json_depth == JSON_MAX_DEPTH) {
+		jse->json_depth_exceeded = 1;
+		return;
+	}
+
+	jse->json_depth++;
+	jse->json_parents[jse->json_depth] = kind;
+	jse->json_nemitted[jse->json_depth] = 0;
+}
+
+static void
+json_nest_end(json_emit_t *jse, json_depthdesc_t kind)
+{
+	VERIFY(kind == JSON_OBJECT || kind == JSON_ARRAY);
+	if (json_has_error(jse)) {
+		return;
+	}
+
+	VERIFY(json_nest_kind(jse) == kind);
+	VERIFY(jse->json_depth > 0);
+	jse->json_depth--;
+}
+
+static void
+json_emit_common(json_emit_t *jse, const char *label, const char *barevalue)
+{
+	json_emit_prepare(jse, label);
+	json_emits(jse, barevalue);
+	json_emit_finish(jse);
+}
+
+/*
+ * Public emitter functions.
+ */
+
+void
+json_object_begin(json_emit_t *jse, const char *label)
+{
+	json_emit_prepare(jse, label);
+	json_emitc(jse, '{');
+	json_nest_begin(jse, JSON_OBJECT);
+}
+
+void
+json_object_end(json_emit_t *jse)
+{
+	json_nest_end(jse, JSON_OBJECT);
+	json_emitc(jse, '}');
+	json_emit_finish(jse);
+}
+
+void
+json_array_begin(json_emit_t *jse, const char *label)
+{
+	json_emit_prepare(jse, label);
+	json_emitc(jse, '[');
+	json_nest_begin(jse, JSON_ARRAY);
+}
+
+void
+json_array_end(json_emit_t *jse)
+{
+	json_nest_end(jse, JSON_ARRAY);
+	json_emitc(jse, ']');
+	json_emit_finish(jse);
+}
+
+void
+json_newline(json_emit_t *jse)
+{
+	if (json_has_error(jse)) {
+		return;
+	}
+
+	VERIFY(json_nest_kind(jse) == JSON_NONE);
+	VERIFY(jse->json_depth == 0);
+	json_emitc(jse, '\n');
+}
+
+void
+json_boolean(json_emit_t *jse, const char *label, json_boolean_t value)
+{
+	VERIFY(value == JSON_B_FALSE || value == JSON_B_TRUE);
+
+	json_emit_common(jse, label, value == JSON_B_TRUE ? "true" : "false");
+}
+
+void
+json_null(json_emit_t *jse, const char *label)
+{
+	json_emit_common(jse, label, "null");
+}
+
+void
+json_int64(json_emit_t *jse, const char *label, int64_t value)
+{
+	char buf[96];
+
+	(void) snprintf(buf, sizeof (buf), "%" PRId64, value);
+
+	json_emit_common(jse, label, buf);
+}
+
+void
+json_uint64(json_emit_t *jse, const char *label, uint64_t value)
+{
+	char buf[96];
+
+	(void) snprintf(buf, sizeof (buf), "%" PRIu64, value);
+
+	json_emit_common(jse, label, buf);
+}
+
+void
+json_double(json_emit_t *jse, const char *label, double value)
+{
+	char buf[96];
+
+	if (!isfinite(value)) {
+		jse->json_nbadfloats++;
+		return;
+	}
+
+	(void) snprintf(buf, sizeof (buf), "%.10e", value);
+
+	json_emit_common(jse, label, buf);
+}
+
+void
+json_utf8string(json_emit_t *jse, const char *label, const char *value)
+{
+	json_emit_prepare(jse, label);
+	json_emit_utf8string(jse, value);
+	json_emit_finish(jse);
+}

--- a/src/http/modules/mpu/deps/jsonemitter.h
+++ b/src/http/modules/mpu/deps/jsonemitter.h
@@ -1,0 +1,162 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2016, Joyent, Inc.
+ */
+
+/*
+ * jsonemitter.h: interface for emitting streaming JSON
+ *
+ * The interfaces here enable callers to emit properly formatted JSON (as
+ * defined by ECMA-404) in a streaming way.
+ *
+ * (1) Initialization and cleanup
+ *
+ *     You instantiate an emitter using:
+ *
+ *         FILE *stream = ...
+ *         json_emit_t *jse = json_create_stdio(stream);
+ *
+ *     "stream" is a stdio stream to which the JSON output will be emitted.
+ *
+ *     json_create_stdio() returns NULL on failure with errno set appropriately.
+ *
+ *     When you've completed the operation and checked for errors, use
+ *     json_fini() to free resources created by the emitter.  After that, no
+ *     other functions may be called using the emitter.  (This does nothing to
+ *     the underlying stdio stream.  The caller may wish to flush or close that
+ *     stream.)
+ *
+ * (2) Emitting data
+ *
+ *     You can emit primitive types of data using a combination of the
+ *     functions:
+ *
+ *        json_boolean()
+ *        json_null()
+ *        json_int64()
+ *        json_uint64()
+ *        json_double()*
+ *        json_utf8string()
+ *
+ *     Note that double-precision floating-point values are emitted with ten
+ *     digits in the current implementation, but this is subject to change to
+ *     in the future without sacrificing precision.
+ *
+ *     You can emit objects and arrays using the functions:
+ *
+ *        json_object_begin(), json_object_end()
+ *        json_array_begin(), json_array_end()
+ *
+ *     All of the emitter functions return void.  See "Error handling".
+ *
+ *     All of the emitter functions take an optional "label" argument that may
+ *     be NULL or a UTF-8 string.  The label must be specified if and only if
+ *     this call is between matching calls to json_object_begin() and
+ *     json_object_end().  The label is used as the name of the property to be
+ *     emitted.  For example:
+ *
+ *         json_object_begin(jse, NULL);
+ *         json_int64(jse, "nerrors", 37);
+ *         json_object_end(jse);
+ *
+ *     would emit the string:
+ *
+ *         {"nerrors":37}
+ *
+ * (3) Newlines
+ *
+ *     A single emitter can be used to emit multiple top-level JSON values in
+ *     sequence.  This is primarily intended for emitting documents consisting
+ *     of newline-separated JSON.  You can use json_newline() to emit a newline
+ *     betwen values.  This function can only be used at the top level (i.e.,
+ *     not inside objects or arrays).
+ *
+ * (4) Error handling
+ *
+ *     There are several operational errors that can happen while emitting JSON.
+ *     These are currently:
+ *
+ *         JSE_STDIO	An error was encountered calling a stdio function.
+ *
+ *         JSE_TOODEEP	The caller attempted to emit more than the supported
+ *         		number of nested objects or arrays.  Currently, 255 is
+ *         		the maximum level of nesting that's supported.
+ *
+ *         JSE_INVAL	The caller attempted to emit an unsupported value.  This
+ *         		currently can only happen if the caller attempts to emit
+ *         		a floating-point value that's infinite or NaN.
+ *
+ *     It is a programmer error to improperly nest objects and arrays, to
+ *     provide labels for values that are not inside objects, or to provide no
+ *     labels for values that are inside objects.
+ *
+ *     The programming interface is optimized for use cases where the caller
+ *     will either attempt to emit an entire JSON document and then check
+ *     whether that completed successfully, or they will emit the document in
+ *     pieces and abort a higher-level operation if emitting the JSON document
+ *     fails.  The emitter functions return void.  To check if there's been any
+ *     error up to this point, use:
+ *
+ *         json_error_t error = json_get_error(jse, buf, bufsz);
+ *
+ *     "error" will be either JSE_NONE or one of the values above.  "buf" and
+ *     "bufsz" work like snprintf(3C): if "bufsz" is positive, then a
+ *     descriptive error message will be copied into the buffer "buf", which
+ *     should be at least "bufsz" bytes.  If "bufsz" is 0, no message is copied,
+ *     and the value of "buf" is ignored.
+ */
+
+#ifndef	_JSONEMITTER_H
+#define	_JSONEMITTER_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+typedef struct json_emit json_emit_t;
+
+typedef enum {
+	JSON_B_FALSE,
+	JSON_B_TRUE
+} json_boolean_t;
+
+typedef enum {
+	JSE_NONE,	/* no error */
+	JSE_STDIO,	/* error from stdio function */
+	JSE_TOODEEP,	/* exceeded maximum supported depth */
+	JSE_INVAL,	/* unsupported value emitted (e.g., NaN) */
+} json_error_t;
+
+json_emit_t *json_create_stdio(FILE *);
+json_emit_t *json_create_string(void);
+json_emit_t *json_create_fixed_string(void *, size_t);
+json_error_t json_get_error(json_emit_t *, char *, size_t);
+void json_fini(json_emit_t *);
+
+void json_object_begin(json_emit_t *, const char *);
+void json_object_end(json_emit_t *);
+
+void json_array_begin(json_emit_t *, const char *);
+void json_array_end(json_emit_t *);
+
+void json_newline(json_emit_t *);
+
+void json_boolean(json_emit_t *, const char *, json_boolean_t);
+void json_null(json_emit_t *, const char *);
+void json_int64(json_emit_t *, const char *, int64_t);
+void json_uint64(json_emit_t *, const char *, uint64_t);
+void json_double(json_emit_t *, const char *, double);
+void json_utf8string(json_emit_t *, const char *, const char *);
+
+/*
+ * For use with emitters created via json_create_string():
+ */
+const char *json_string_cstr(json_emit_t *);
+size_t json_string_len(json_emit_t *);
+void json_string_clear(json_emit_t *);
+
+#endif /* not defined _JSONEMITTER_H_ */

--- a/src/http/modules/mpu/ngx_http_mpu_commit_module.c
+++ b/src/http/modules/mpu/ngx_http_mpu_commit_module.c
@@ -1,0 +1,1435 @@
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.*
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+/*
+ * Module to perform multi-part upload commits.
+ *
+ * The multipart upload is defined in RFD 65. At its core, the job here is to
+ * take a list of files, concatenate them, and then return the md5 checksum to
+ * the client.
+ *
+ * This is implemented as an nginx module, which is currently compiled into
+ * nginx. As part of nginx, there are two main things that we define:
+ *
+ * 1. A function which initializes and inserts us into the request handling
+ * array (mpu_init()).
+ *
+ * 2. Functions to manipulate the configuration options and a table of options
+ * (mpu_create_loc_conf() and mpu_merge_loc_conf()).
+ *
+ * nginx's configuration is logically broken down into different name spaces
+ * based on what it influences. The MPU module focuses on the 'location' level,
+ * which corresponds to the 'location' keyword, which is meant to refer to a
+ * section of the server's HTTP name space. When nginx is started up, it invokes
+ * our two configuration functions for different portions of the configuration
+ * tree. A user is required to set 'mpu_enabled', for a given section to be
+ * relevant for MPUs. All URLs under a given location will be used for MPU
+ * processing.
+ *
+ * As part of the mpu_init() function, this module inserts its own function into
+ * the request processing pipeline. This function, mpu_handler(), is called for
+ * most HTTP requets. If this function returns NGX_DECLINED, then we move onto
+ * the next phase of the pipeline. Otherwise, if we return that we're handling
+ * this request, nginx will wait for us to finish the request. Finally, if we
+ * return an error, then nginx will return an error to the client immediately.
+ *
+ * If the 'mpu_enabled' flag is not set for the given location which the URI
+ * maps to, then we'll always return NGX_DECLINED, so that it is handled by
+ * another part of the system. This is how the dav module or the basic HTTP get
+ * part works.
+ *
+ * If 'mpu_enabled' has been set to on, then we proceed to process the request
+ * as an MPU. This happens in a few high-level steps:
+ *
+ * 1. Receive the entire MPU body
+ * 2. Read in and parse the entire MPU body
+ * 3. Validate the MPU JSON payload
+ * 4. Perform the actual copy and rename operations (if needed)
+ * 5. Return the calculated md5 sum to the user
+ *
+ * Because we have to read, checksum, and write each part of an MPU to a
+ * destination temporary file, there are some gotchas with how we're performing
+ * this. By default, nginx has a single thread that processes an event loop.
+ * Doing all these file operations does not really fit into the classic event
+ * loop model. To deal with that, all of these blocking operations happen inside
+ * a specifically configured thread pool.
+ *
+ * More concretely, step 1 happens on the event loop. We ask nginx for the
+ * entire body. This body gets streamed to disk asynchronously by nginx. We ask
+ * nginx to stream this body asynchronously by calling the
+ * ngx_http_read_client_request_body() function and specifying a callback when
+ * it's done. Once we have kicked off this asynchronous operation, it is up to
+ * us to tell nginx when we're done with the request. To do that we need to call
+ * ngx_http_finalize_request() which vectors control to mpu_post_body() on
+ * completion.
+ *
+ * Once the body has been read successfully by nginx, we start a thread pool job
+ * by calling ngx_thread_task_post(). The thread pool allows us to specify two
+ * functions. One function to run on the thread pool (mpu_task_handler()) and a
+ * second function to run on the event loop (the main thread), when the thread
+ * pool job is done (mpu_post_thread()). We can only call back into the nginx
+ * HTTP handling code when we're on the main thread. So we can't call
+ * ngx_http_finalize_request() or anything related until we reach
+ * mpu_post_thread().
+ *
+ * The thread pool job (mpu_post_handler()), reads that file into memory, parses
+ * the JSON blob, and then proceeds to execute the MPU after validating it. It's
+ * worth pointing out that the reason we stream this to disk and then read it in
+ * is because that allows us to have a single buffer which can be parsed for the
+ * MPU blob, which is capped at 512K as part of configuration. nginx may be
+ * convinced to keep it in memory, but it may only end up as a series of chained
+ * buffers. Unfortunately, the supporting libraries in use don't support
+ * disparate, chained buffers and thus we need to construct a single buffer with
+ * the contents of the MPU JSON body.
+ *
+ * In the thread pool, we check to see if the file already exists. If it does,
+ * we move on to reading its checksum and verifying the file size matches what
+ * we expect from the request. If the file has already been constructed and the
+ * checksum matches, we don't try to reconstruct the file. This is necessary
+ * because a request can be resubmitted and the components making up the file
+ * may have already been deleted after a previous submission.
+ *
+ * If the output file does not exist, we do all of our work in a temporary file.
+ * We read in and calculate a running md5 checksum of the object and write out
+ * the files in a cat(1)-like fashion. Once that's been assembled, we verify the
+ * size of the file and the checksum against the request data. If everything
+ * appears valid, we'll fsync and rename.
+ *
+ * Once this is done, we leave the thread pool and return to the main nginx
+ * event loop.  From that context, we'll put together the response information
+ * and give that to the client, finishing this request.
+ *
+ * Misc. Implementation Notes
+ * --------------------------
+ *
+ *  - nginx strings are never null-terminated, they're kept as a pair of
+ *    pointers pointing to the start and end of the string. This means that
+ *    routines like ngx_snprintf() and co. do not append the '\0' character as
+ *    you might expect. If you're expecting things to be null terminated, use
+ *    libc routines. A side effect of this is that ngx_*printf cannot be used to
+ *    do overflow detection. In general, when performing overflow detection, use
+ *    snprintf(3C).
+ *
+ *  - The nginx memory allocation routines have different lifetimes. The
+ *    ngx_alloc() and ngx_free() routines are like malloc and free, it is the
+ *    responsibility of this module to keep track of them. However, the
+ *    ngx_pcalloc() allocates memory tied to the lifetime of the HTTP request.
+ *    As long as the allocation is less than a page in size, it will be freed as
+ *    part of the request terminating. Note, some things like
+ *    ngx_thread_task_alloc() use this as part of their request.
+ *
+ *  - If additional allocations are required for some reason, the ngx_pcalloc()
+ *    family of functions should be used for small allocations that are tied to
+ *    the request life cycle.
+ *
+ *  - Once we reach the point where we are running on a thread pool, all errors
+ *    should go through mpu_set_error() which take care of making sure that both
+ *    our internal request structure metadata is correct and that the error is
+ *    properly logged and recorded for replying to the client.
+ *
+ *  - nginx has the ability to automatically clean up and remove temporary
+ *    files. We use this for the temporary file that represents the MPU JSON
+ *    payload. However, we do not use this for the actual temporary file that we
+ *    end up creating for renaming. The reason for this is that that temporary
+ *    file will ultimately be renamed when successful. If it's successfully
+ *    renamed, then we don't want to unlink the file, as nginx could have
+ *    generated another temporary file with the same name. Instead, we manually
+ *    clean that up.
+ *
+ *  - For each location entry, nginx calls our initialize function,
+ *    mpu_create_loc_conf(), and then it merges data between subsequent levels
+ *    with the mpu_merge_loc_conf() function. The _create_ function should
+ *    always initialize everything to indicate that values aren't set.
+ */
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <ngx_thread_pool.h>
+#include <ngx_md5.h>
+#include <strings.h>
+#include <libgen.h>
+#include <stdarg.h>
+#include <sys/debug.h>
+#include <atomic.h>
+
+#include "deps/json-nvlist.h"
+#include "deps/jsonemitter.h"
+
+/*
+ * Be paranoid about making sure we have 64-bit interfaces.
+ */
+#if defined(__i386) && !defined(_FILE_OFFSET_BITS)
+#error "32-bit build without _FILE_OFFSET_BITS"
+#endif
+
+#if defined(__i386) && _FILE_OFFSET_BITS != 64
+#error "incorrect value for _FILE_OFFSET_BITS"
+#endif
+
+#ifndef	MIN
+#define	MIN(a, b)	((a) < (b) ? (a) : (b))
+#endif
+
+/*
+ * This module attempts to be agnostic to the md5 implementation in use;
+ * however, it does expect that the headers define MD5_DIGEST_LENGTH. This is
+ * currently defined by both the system headers on illumos and OpenSSL. While we
+ * could define it ourselves, if it's missing, that's a sign that we should
+ * figure out what md5 implementation we're actually using.
+ */
+#ifndef	MD5_DIGEST_LENGTH
+#error "md5 implementation headers missing common MD5_DIGEST_LENGTH macro"
+#endif
+
+/*
+ * We read up to 512k into a buffer for the commit POST request body. Anything
+ * larger is thrown out. This number is based on the idea that we could have
+ * have 10k UUIDs in parts, which would translate into around 400k characters.
+ */
+#define	MPU_COMMIT_POST_SIZE	(512 * 1024)
+
+/*
+ * We use 2 MB buffer sizes to try and maximize the amount of heap usage.
+ */
+#define	MPU_COMMIT_RW_SIZE	(2 * 1024 * 1024)
+
+/*
+ * This is the length of C buffer that encodes a base64 encoded value.
+ */
+#define	MPU_MD5_B64_LEN	(ngx_base64_encoded_length(MD5_DIGEST_LENGTH) + 1)
+
+/*
+ * This is the size of our static error buffer in the error handler.
+ */
+#define	MPU_ERR_BUF_LEN		512
+
+typedef struct {
+	ngx_flag_t		mcl_enabled;
+	ngx_thread_pool_t	*mcl_pool;
+	ngx_str_t		mcl_root;
+} mpu_loc_conf_t;
+
+/*
+ * This is a per-request structure that is allocated as part of the thread pool
+ * task allocation.
+ */
+typedef struct {
+	ngx_http_request_t	*mpcr_http;
+	ngx_thread_task_t	*mpcr_task;
+	char			*mpcr_buf;
+	size_t			mpcr_buflen;
+	const char		*mpcr_account;
+	const char		*mpcr_objid;
+	const char		*mpcr_root;
+	const char		*mpcr_req_md5;
+	int64_t			mpcr_nbytes;
+	ngx_int_t		mpcr_status;
+	ngx_buf_t		mpcr_ngx_buf;
+	ngx_md5_t		mpcr_md5;
+	unsigned char		mpcr_md5_buf[MD5_DIGEST_LENGTH];
+	char			mpcr_md5_b64[MPU_MD5_B64_LEN];
+	char			mpcr_error[MPU_ERR_BUF_LEN];
+} mpu_request_t;
+
+/* Forwards */
+ngx_module_t ngx_http_mpu_commit_module;
+
+static const char *mpu_content = "application/json";
+
+/*
+ * Stat to keep track of times we can't schedule data on a thread pool.
+ */
+volatile uint64_t mpu_overloads;
+
+/*
+ * Basically we want a way to indicate in a few functions that the output file
+ * already exists. Hence the MPU_EALREADY.
+ */
+typedef enum {
+	MPU_FAILURE	= -1,
+	MPU_SUCCESS	= 0,
+	MPU_EALREADY	= 1
+} mpu_status_t;
+
+static char *
+mpu_set_pool(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+	ngx_str_t name;
+	ngx_thread_pool_t *tp;
+	ngx_str_t  *value;
+	mpu_loc_conf_t *mcl = conf;
+
+	value = cf->args->elts;
+	name.len = value[1].len;
+	name.data = value[1].data;
+
+	tp = ngx_thread_pool_add(cf, &name);
+	if (tp == NULL) {
+		ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+		    "invalid thread pool specified for MPU commit");
+		return (NGX_CONF_ERROR);
+	}
+	mcl->mcl_pool = tp;
+
+	return (NGX_CONF_OK);
+}
+
+static ngx_command_t  mpu_commands[] = {
+	{ ngx_string("mpu_enabled"),
+	    NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+	    ngx_conf_set_flag_slot,
+	    NGX_HTTP_LOC_CONF_OFFSET,
+	    offsetof(mpu_loc_conf_t, mcl_enabled),
+	    NULL },
+
+	{ ngx_string("mpu_pool"),
+	    NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+	    mpu_set_pool,
+	    NGX_HTTP_LOC_CONF_OFFSET,
+	    0, NULL },
+
+	{ ngx_string("mpu_root"),
+	    NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+	    ngx_conf_set_str_slot,
+	    NGX_HTTP_LOC_CONF_OFFSET,
+	    offsetof(mpu_loc_conf_t, mcl_root),
+	    NULL },
+
+    ngx_null_command
+};
+
+static void *
+mpu_create_loc_conf(ngx_conf_t *cf)
+{
+	mpu_loc_conf_t *conf;
+
+	conf = ngx_pcalloc(cf->pool, sizeof (mpu_loc_conf_t));
+	if (conf == NULL) {
+		return (NULL);
+	}
+
+	conf->mcl_enabled = NGX_CONF_UNSET;
+	conf->mcl_pool = NGX_CONF_UNSET_PTR;
+	conf->mcl_root.len = 0;
+	conf->mcl_root.data = NULL;
+
+	return (conf);
+}
+
+static char *
+mpu_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+	mpu_loc_conf_t *prev = parent;
+	mpu_loc_conf_t *conf = child;
+
+	ngx_conf_merge_value(conf->mcl_enabled, prev->mcl_enabled, 0);
+	ngx_conf_merge_ptr_value(conf->mcl_pool, prev->mcl_pool,
+	    NGX_CONF_UNSET_PTR);
+	ngx_conf_merge_str_value(conf->mcl_root, prev->mcl_root, "");
+	if (conf->mcl_enabled == 1 && conf->mcl_pool == NGX_CONF_UNSET_PTR) {
+		ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+		    "missing required MPU setting: \"mpu_pool\"");
+		return (NGX_CONF_ERROR);
+	}
+	if (conf->mcl_enabled == 1 && (conf->mcl_root.len == 0 ||
+	    (conf->mcl_root.len == 0 && conf->mcl_root.data[0] == '\0'))) {
+		ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+		    "missing required MPU setting \"mpu_root\"");
+		return (NGX_CONF_ERROR);
+	}
+	return (NGX_CONF_OK);
+}
+
+/*
+ * Create a minimal form of the error message that occurred. This is used in
+ * cases where we have hit internal memory issues and we know that the string
+ * being embedded in the JSON does not require escaping.
+ */
+static void
+mpu_set_error_fallback(mpu_request_t *mpcr, const char *code)
+{
+	(void) snprintf(mpcr->mpcr_error, sizeof (mpcr->mpcr_error),
+	    "{ \"code\": \"%s\" }", code);
+}
+
+/*
+ * We always render the string that we want to pass to nginx ourselves so that
+ * way we can include strerror of errno or not as we need. Format this once for
+ * nginx and then once as JSON.
+ */
+static void
+mpu_set_error(mpu_request_t *mpcr, int status, int err, char *format, ...)
+{
+	int off, ret;
+	va_list ap;
+	const char *code;
+	json_emit_t *jse;
+	char buf[MPU_ERR_BUF_LEN];
+
+	ngx_http_request_t *r = mpcr->mpcr_http;
+	mpcr->mpcr_status = status;
+
+	va_start(ap, format);
+	ret = vsnprintf(buf, sizeof (buf), format, ap);
+	ngx_log_error(NGX_LOG_ERR, r->connection->log, err, "%s", buf);
+	mpcr->mpcr_error[0] = '\0';
+
+
+	/*
+	 * Translate the HTTP status code into an error that seems appropriate
+	 * for the given issue that matches what Muskie and co. are likely to
+	 * use.
+	 */
+	switch (status) {
+	case NGX_HTTP_BAD_REQUEST:
+	case NGX_HTTP_CONFLICT:
+		code = "BadRequestError";
+		break;
+	case NGX_HTTP_INTERNAL_SERVER_ERROR:
+	default:
+		code = "InternalError";
+		break;
+	}
+
+	if (ret == -1 || ret >= MPU_ERR_BUF_LEN) {
+		mpu_set_error_fallback(mpcr, code);
+		va_end(ap);
+		return;
+	}
+
+	if (err != 0) {
+		off = snprintf(buf + ret, sizeof (buf) - ret, ": %s",
+		    strerror(err));
+		if (off == -1 || off + ret >= MPU_ERR_BUF_LEN) {
+			mpu_set_error_fallback(mpcr, code);
+			va_end(ap);
+			return;
+		}
+	}
+	va_end(ap);
+
+	jse = json_create_fixed_string(mpcr->mpcr_error,
+	    sizeof (mpcr->mpcr_error));
+	if (jse == NULL) {
+		mpu_set_error_fallback(mpcr, code);
+		return;
+	}
+	json_object_begin(jse, NULL);
+	json_utf8string(jse, "code", code);
+	json_utf8string(jse, "message", buf);
+	json_object_end(jse);
+	if (json_get_error(jse, buf, sizeof (buf)) != JSE_NONE) {
+		mpu_set_error_fallback(mpcr, code);
+		json_fini(jse);
+		return;
+	}
+	json_fini(jse);
+}
+
+/*
+ * Read in a request from the nginx temporary file
+ */
+static boolean_t
+mpu_readin_request(mpu_request_t *mpcr, nvlist_t **nvl)
+{
+	ssize_t ret;
+	off_t off;
+	struct stat st;
+	int fd;
+	nvlist_parse_json_error_t nverr;
+	ngx_http_request_t *r;
+	char *buf = mpcr->mpcr_buf;
+
+	r = mpcr->mpcr_http;
+	fd = r->request_body->temp_file->file.fd;
+	if (ngx_fd_info(fd, &st) != 0) {
+		VERIFY3S(errno, !=, EFAULT);
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, ngx_errno,
+		    "failed to stat mpu upload file %s",
+		    r->request_body->temp_file->file.name);
+		return (B_FALSE);
+	}
+
+	if (st.st_size >= MPU_COMMIT_POST_SIZE) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+		    "POST body size was %lld, larger than max of %d",
+		    st.st_size, MPU_COMMIT_POST_SIZE);
+		return (B_FALSE);
+	}
+
+	buf[0] = '\0';
+	off = 0;
+	do {
+		size_t toread = MIN((size_t)st.st_size, (size_t)mpcr->mpcr_buflen);
+
+		/*
+		 * Use pread(2), we don't know where nginx has left off reading
+		 * this file nor do we know where it expects to be.
+		 */
+		ret = pread(fd, buf + off, toread, off);
+		if (ret < 0) {
+			VERIFY3S(errno, !=, EFAULT);
+			mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR,
+			    ngx_errno, "failed to pread %lld bytes from fd %d "
+			    "at off %lld from post body", toread, fd, off);
+			return (B_FALSE);
+		}
+		off += ret;
+		st.st_size -= toread;
+
+		if (ret == 0 && st.st_size != 0) {
+			mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, 0,
+			    "hit EOF after reading %lld bytes, but still had "
+			    "%lld remaining", off, st.st_size);
+			return (B_FALSE);
+
+		}
+	} while (st.st_size > 0);
+
+	ret = nvlist_parse_json(buf, off, nvl, NVJSON_FORCE_INTEGER, &nverr);
+
+	if (ret != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, nverr.nje_errno,
+		    "mpu commit encountered invalid JSON at pos %ld: %s",
+		    nverr.nje_pos, nverr.nje_message);
+		return (B_FALSE);
+	}
+
+	return (B_TRUE);
+}
+
+static boolean_t
+mpu_alloc_tmpfile(mpu_request_t *mpcr, ngx_file_t *file)
+{
+	ngx_http_core_loc_conf_t *clcf;
+	ngx_http_request_t *r = mpcr->mpcr_http;
+
+	clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+
+	file->fd = NGX_INVALID_FILE;
+	file->log = r->connection->log;
+
+	if (ngx_create_temp_file(file, clcf->client_body_temp_path, r->pool,
+	    1, 0, 0660) != NGX_OK) {
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, 0,
+		    "failed to create temporary file for MPU output");
+		return (B_FALSE);
+	}
+
+	return (B_TRUE);
+}
+
+/*
+ * Verify that the client md5 checksum, if present, matches what we have
+ * generated for our file. Note, we always check the base64 encoded md5
+ * checksum. See the notes in ngx_htp_dav_module.c for more on why we do it this
+ * way.
+ */
+static boolean_t
+mpu_verify_md5(mpu_request_t *mpcr)
+{
+	if (mpcr->mpcr_req_md5 == NULL)
+		return (B_TRUE);
+
+	if (strcmp(mpcr->mpcr_req_md5, mpcr->mpcr_md5_b64) != 0) {
+		/*
+		 * We use a 469 which is what we use elsewhere in mako.
+		 */
+		mpu_set_error(mpcr, 469, 0, "md5 checksums mismatched: client "
+		    "b64 md5 is %s, calculated value is %s", mpcr->mpcr_req_md5,
+		    mpcr->mpcr_md5_b64);
+		return (B_FALSE);
+	}
+
+	return (B_TRUE);
+}
+
+/*
+ * Convert the md5 sum to a b64 value
+ */
+static boolean_t
+mpu_convert_md5(mpu_request_t *mpcr)
+{
+	ngx_str_t md5, b64;
+
+	md5.data = (u_char *)mpcr->mpcr_md5_buf;
+	md5.len = MD5_DIGEST_LENGTH;
+	b64.data = (u_char *)mpcr->mpcr_md5_b64;
+	ngx_encode_base64(&b64, &md5);
+	if (b64.len != ngx_base64_encoded_length(MD5_DIGEST_LENGTH)) {
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, 0,
+		    "MD5 b64 encoding did not result in proper length");
+		return (B_FALSE);
+	}
+	b64.data[b64.len] = '\0';
+
+	return (B_TRUE);
+}
+
+/*
+ * This function calculates the md5 sum of an existing output file. We must
+ * include the md5 for every successful create, thus we must calculate this even
+ * for a file that already exists. Recall, we could have generated an output
+ * file, but crashed before the caller got a successful response, hence we owe
+ * them a computed md5 value.
+ */
+static boolean_t
+mpu_determine_output_md5(mpu_request_t *mpcr, int fd)
+{
+	/*
+	 * It's possible we have already started calculating the md5 sum of the
+	 * object before this function is called, so we need to reinitialize the
+	 * state of the md5 sum before starting from the beginning of the object.
+	 */
+	ngx_md5_init(&mpcr->mpcr_md5);
+
+	for (;;) {
+		ssize_t ret;
+
+		ret = read(fd, mpcr->mpcr_buf, mpcr->mpcr_buflen);
+		if (ret == 0)
+			break;
+		if (ret < 1) {
+			VERIFY3S(errno, !=, EFAULT);
+			mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR,
+			    errno, "failed to read from input file, fd %d", fd);
+			return (B_FALSE);
+		}
+
+		ngx_md5_update(&mpcr->mpcr_md5, mpcr->mpcr_buf, ret);
+	}
+
+	ngx_md5_final(mpcr->mpcr_md5_buf, &mpcr->mpcr_md5);
+	if (!mpu_convert_md5(mpcr))
+		return (B_FALSE);
+
+	if (!mpu_verify_md5(mpcr))
+		return (B_FALSE);
+
+	return (B_TRUE);
+}
+
+/*
+ * Verify that the output file exists and if so, check that both the size and
+ * md5 sum match. Note, we must also fsync the parent directory of this file.
+ * There's a potential race condition where we get here after the rename
+ * succeeds, but before the fsync of the parent directory completes. In that
+ * case, we could complete this before the rename was guaranteed via fsync(2).
+ * That would end up causing us to incorrectly acknowledge this as visible if
+ * the system crashed before that fsync completed. As such, we do it here.
+ */
+static mpu_status_t
+mpu_check_exists(mpu_request_t *mpcr)
+{
+	int fd, ret;
+	char outfile[PATH_MAX];
+	struct stat sb;
+
+	if ((ret = snprintf(outfile, sizeof (outfile), "%s/%s/%s",
+	    mpcr->mpcr_root, mpcr->mpcr_account, mpcr->mpcr_objid)) >=
+	    PATH_MAX) {
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, 0,
+		    "failed to assemble mpu output file, overflowed internal "
+		    "snprintf buffer, needed %d bytes, had %d", ret,
+		    sizeof (outfile));
+		return (MPU_FAILURE);
+	}
+
+	if ((fd = ngx_open_file(outfile, O_RDONLY | O_NOCTTY, NGX_FILE_OPEN,
+	    0660)) < 0) {
+		VERIFY3S(errno, !=, EFAULT);
+		if (errno == ENOENT)
+			return (MPU_SUCCESS);
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, ngx_errno,
+		    "failed to open output file %s", outfile);
+		return (MPU_FAILURE);
+	}
+
+	if (ngx_fd_info(fd, &sb) != 0) {
+		VERIFY3S(errno, !=, EFAULT);
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, ngx_errno,
+		    "failed to stat output file %s", outfile);
+
+		(void) ngx_close_file(fd);
+		return (MPU_FAILURE);
+	}
+
+	if (sb.st_size != mpcr->mpcr_nbytes) {
+		(void) ngx_close_file(fd);
+
+		mpu_set_error(mpcr, NGX_HTTP_CONFLICT, 0,
+		    "size of MPU output file %s is actually %lld, expected "
+		    "%lld", outfile, sb.st_size, mpcr->mpcr_nbytes);
+		return (MPU_FAILURE);
+	}
+
+	ret = mpu_determine_output_md5(mpcr, fd);
+	(void) ngx_close_file(fd);
+	if (ret == B_FALSE) {
+		return (MPU_FAILURE);
+	}
+
+	/*
+	 * fsync(2) the parent directory.
+	 */
+	(void) snprintf(outfile, sizeof (outfile), "%s/%s", mpcr->mpcr_root,
+	    mpcr->mpcr_account);
+	fd = ngx_open_file(outfile, O_RDONLY | O_NOCTTY, NGX_FILE_OPEN, 0660);
+	if (fd < 0) {
+		VERIFY3S(errno, !=, EFAULT);
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, errno,
+		    "failed to open output directory %s for syncing",
+		    outfile);
+		return (MPU_FAILURE);
+	}
+
+	if (fsync(fd) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, errno,
+		    "failed to fsync parent directory %s", outfile);
+		(void) ngx_close_file(fd);
+		return (MPU_FAILURE);
+	}
+	(void) ngx_close_file(fd);
+
+	return (MPU_EALREADY);
+}
+
+static boolean_t
+mpu_append_file(mpu_request_t *mpcr, int fromfd, int tofd)
+{
+	for (;;) {
+		ssize_t ret, towrite;
+		off_t off;
+
+		ret = read(fromfd, mpcr->mpcr_buf, mpcr->mpcr_buflen);
+		if (ret == 0)
+			break;
+		if (ret < 0) {
+			VERIFY3S(errno, !=, EFAULT);
+			mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR,
+			    errno, "failed to read from input file, fd %d",
+			    fromfd);
+			return (B_FALSE);
+		}
+
+		ngx_md5_update(&mpcr->mpcr_md5, mpcr->mpcr_buf, ret);
+
+		towrite = ret;
+		off = 0;
+		do {
+			ret = write(tofd, mpcr->mpcr_buf + off, towrite);
+			if (ret < 0) {
+				VERIFY3S(errno, !=, EFAULT);
+				mpu_set_error(mpcr,
+				    NGX_HTTP_INTERNAL_SERVER_ERROR, errno,
+				    "failed to write to output file, fd %d",
+				    tofd);
+				return (B_FALSE);
+			}
+			towrite -= ret;
+			off += ret;
+		} while (towrite > 0);
+	}
+
+	return (B_TRUE);
+}
+
+/*
+ * By the time this function finishes, the temporary input file must have been
+ * renamed or removed. If this module does not remove the temporary file, then
+ * nothing will and we can end up wasting space. Other functions don't have this
+ * problem, as the caller knows enough to be able to always clean things up on
+ * failure.
+ */
+static boolean_t
+mpu_rename(mpu_request_t *mpcr, ngx_file_t *infile)
+{
+	int ret, dirfd;
+	char outfile[PATH_MAX];
+	ngx_http_request_t *r;
+
+	r = mpcr->mpcr_http;
+	if ((ret = snprintf(outfile, sizeof (outfile), "%s/%s/%s",
+	    mpcr->mpcr_root, mpcr->mpcr_account, mpcr->mpcr_objid)) >=
+	    PATH_MAX) {
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, 0,
+		    "attempt to create path for output file with account "
+		    "%s and object %s overflowed internal buffer, needed "
+		    "%d bytes, had %d", mpcr->mpcr_account, mpcr->mpcr_objid,
+		    ret, PATH_MAX);
+		if (ngx_delete_file(infile->name.data) == NGX_FILE_ERROR) {
+			VERIFY3S(errno, !=, EFAULT);
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, errno,
+			    "failed to remove temporary file %s after size "
+			    "check failed", infile->name.data);
+		}
+		return (B_FALSE);
+	}
+
+	if (fsync(infile->fd) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, errno,
+		    "failed to fsync temporary file %s", infile->name.data);
+		if (ngx_delete_file(infile->name.data) == NGX_FILE_ERROR) {
+			VERIFY3S(errno, !=, EFAULT);
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, errno,
+			    "failed to remove temporary file %s after size "
+			    "check failed", infile->name.data);
+		}
+		return (B_FALSE);
+	}
+
+	if (rename((char *)infile->name.data, outfile) != 0) {
+		VERIFY3S(errno, !=, EFAULT);
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, errno,
+		    "failed to rename temporary file %s to %s",
+		    infile->name.data, outfile);
+		if (ngx_delete_file(infile->name.data) == NGX_FILE_ERROR) {
+			VERIFY3S(errno, !=, EFAULT);
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, errno,
+			    "failed to remove temporary file %s after size "
+			    "check failed", infile->name.data);
+		}
+		return (B_FALSE);
+	}
+
+	if ((dirfd = ngx_open_file(dirname(outfile), O_RDONLY|O_NOCTTY,
+	    NGX_FILE_OPEN, 0660)) < 0) {
+		VERIFY3S(errno, !=, EFAULT);
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, errno,
+		    "failed to open output directory %s for syncing",
+		    outfile);
+		return (B_FALSE);
+	}
+
+	if (fsync(dirfd) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, errno,
+		    "failed to fsync parent directory %s", outfile);
+		(void) ngx_close_file(dirfd);
+		return (B_FALSE);
+	}
+	(void) ngx_close_file(dirfd);
+
+	return (B_TRUE);
+}
+
+/*
+ * Go through and make sure that every key is valid and that it fits inside of
+ * our internal buffers.
+ */
+static boolean_t
+mpu_check_parts(mpu_request_t *mpcr,
+    const char *account, nvlist_t *parts, uint_t nparts)
+{
+	uint32_t i;
+
+	for (i = 0; i < nparts; i++) {
+		char key[64];
+		char *file;
+		char path[PATH_MAX];
+		int ret;
+
+		(void) snprintf(key, sizeof (key), "%d", i);
+		if (nvlist_lookup_string(parts, key, &file) != 0) {
+			mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+			    "told %d parts exist, but part %d is not a valid "
+			    "string", nparts, i);
+			return (B_FALSE);
+		}
+
+		/*
+		 * Explicitly forbid the presence of the characters '/' and '.'
+		 * in the string to help deal with someone trying to path escape
+		 * via the construction below.
+		 */
+		if (strchr(file, '.') != NULL || strchr(file, '/') != NULL) {
+			mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+			    "found illegal character, '.' or '/' in part %d "
+			    "name", i);
+			return (B_FALSE);
+		}
+
+		if ((ret = snprintf(path, sizeof (path), "%s/%s/%s",
+		    mpcr->mpcr_root, account, file)) >= PATH_MAX) {
+			mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+			    "attempt to create path for part %d with account "
+			    "%s and part %s overflowed internal buffer, needed "
+			    "%d bytes, had %d", account, file, ret, PATH_MAX);
+			return (B_FALSE);
+		}
+	}
+
+	return (B_TRUE);
+}
+
+static mpu_status_t
+mpu_nvl_append_parts(mpu_request_t *mpcr, nvlist_t *parts, uint32_t nparts,
+    ngx_file_t *tmpfile)
+{
+	uint32_t i;
+
+	for (i = 0; i < nparts; i++) {
+		char key[64];
+		char *file;
+		char path[PATH_MAX];
+		int fd;
+		boolean_t ret;
+
+		(void) snprintf(key, sizeof (key), "%d", i);
+		file = fnvlist_lookup_string(parts, key);
+		(void) snprintf(path, sizeof (path), "%s/%s/%s",
+		    mpcr->mpcr_root, mpcr->mpcr_account, file);
+
+		fd = ngx_open_file(path, O_RDONLY|O_NOCTTY, NGX_FILE_OPEN,
+		    0660);
+		if (fd < 0) {
+			int err = errno;
+			VERIFY3S(errno, !=, EFAULT);
+			/*
+			 * We encountered a missing part. If we're missing a
+			 * part, then that might indicate that we're racing with
+			 * another commit. As such, we try to check if the
+			 * output file exists and if so, leverage that.
+			 */
+			if (errno == ENOENT && mpu_check_exists(mpcr) ==
+			    MPU_EALREADY) {
+				return (MPU_EALREADY);
+			}
+
+			/*
+			 * Clobber whatever error we may have encountered above
+			 * with the actual thing we originally saw.
+			 */
+			mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, err,
+			    "failed to open file %s for part %d", path, i);
+			return (MPU_FAILURE);
+		}
+
+		ret = mpu_append_file(mpcr, fd, tmpfile->fd);
+		(void) ngx_close_file(fd);
+		if (ret == B_FALSE)
+			return (MPU_FAILURE);
+	}
+
+	return (MPU_SUCCESS);
+}
+
+static void
+mpu_cleanup_parts(mpu_request_t *mpcr, nvlist_t *parts, uint_t nparts)
+{
+	uint32_t i;
+	ngx_http_request_t *r = mpcr->mpcr_http;
+
+	for (i = 0; i < nparts; i++) {
+		char key[64];
+		char *file;
+		char path[PATH_MAX];
+
+		(void) snprintf(key, sizeof (key), "%d", i);
+		file = fnvlist_lookup_string(parts, key);
+		(void) snprintf(path, sizeof (path), "%s/%s/%s",
+		    mpcr->mpcr_root, mpcr->mpcr_account, file);
+
+		/*
+		 * If we fail to remove a part, we're in a bad situation. In
+		 * theory we've successfully created everything else about this
+		 * request. Unfortunately, failing the request at this point is
+		 * not going to be very helpful. Instead, we simply log, and
+		 * move on. This means that these abandoned parts will need to
+		 * be eventually cleaned up. We don't bother logging about
+		 * ENOENT as that may be a natural state given races between
+		 * multiple MPUs.
+		 */
+		if (unlink(path) != 0 && errno != ENOENT) {
+			VERIFY3S(errno, !=, EFAULT);
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, errno,
+			    "failed to remove file %s for part %d", path, i);
+		}
+	}
+
+}
+
+static boolean_t
+mpu_verify_size(mpu_request_t *mpcr, ngx_file_t *fp)
+{
+	struct stat st;
+
+	if (ngx_fd_info(fp->fd, &st) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_INTERNAL_SERVER_ERROR, ngx_errno,
+		    "failed to stat temporary file %s", fp->name.data);
+		return (B_FALSE);
+	}
+
+	if (st.st_size != mpcr->mpcr_nbytes) {
+		/*
+		 * This is a bit of a tricky case, it's hard to say what the
+		 * right error is. It could be that this module failed to
+		 * assemble the output file correctly, or that what we were
+		 * given didn't match. For now we opt to return a 409, as
+		 * there's not necessarily a better option.
+		 */
+		mpu_set_error(mpcr, NGX_HTTP_CONFLICT, 0,
+		    "assembled temporary file %s has size %lld bytes, request "
+		    "specified %lld bytes", fp->name.data, st.st_size,
+		    mpcr->mpcr_nbytes);
+		return (B_FALSE);
+	}
+
+	return (B_TRUE);
+}
+
+/*
+ * Validate the various parts of the MPU commit message and process them.
+ */
+static boolean_t
+mpu_nvl_process(mpu_request_t *mpcr, nvlist_t *nvl)
+{
+	int ret;
+	uint32_t nparts;
+	int64_t version, nbytes;
+	char *account, *objid, *req_md5;
+	nvlist_t *parts;
+	ngx_file_t tmpfile;
+	ngx_http_request_t *r;
+
+	r = mpcr->mpcr_http;
+	if ((ret = nvlist_lookup_int64(nvl, "version", &version)) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, ret,
+		    "mpu commit JSON missing version");
+		return (B_FALSE);
+	}
+
+	if (version != 1) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+		    "mpu commit encountered unknown version: %lld", version);
+		return (B_FALSE);
+	}
+
+	if ((ret = nvlist_lookup_int64(nvl, "nbytes", &nbytes)) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, ret,
+		    "mpu commit JSON missing nbytes");
+		return (B_FALSE);
+	}
+
+	if (nbytes <= 0) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+		    "mpu commit encountered invalid bytes: %lld", nbytes);
+		return (B_FALSE);
+	}
+
+	if ((ret = nvlist_lookup_string(nvl, "account", &account)) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, ret,
+		    "mpu commit JSON missing account");
+		return (B_FALSE);
+	}
+
+	if ((ret = nvlist_lookup_string(nvl, "objectId", &objid)) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, ret,
+		    "mpu commit JSON missing objectId");
+		return (B_FALSE);
+	}
+
+	if ((ret = nvlist_lookup_nvlist(nvl, "parts", &parts)) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, ret,
+		    "mpu commit JSON missing parts");
+		return (B_FALSE);
+	}
+
+	if (nvlist_lookup_boolean(parts, ".__json_array") != 0 ||
+	    nvlist_lookup_uint32(parts, "length", &nparts) != 0) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+		    "mpu commit JSON parts not parsed to a valid array");
+		return (B_FALSE);
+	}
+
+	/*
+	 * The request md5 value is optional, and should be a base64 encoded
+	 * value.
+	 */
+	if (nvlist_lookup_string(nvl, "md5", &req_md5) == 0) {
+		u_char buf[MD5_DIGEST_LENGTH];
+		ngx_str_t dec, enc;
+
+		if ((ret = strlen(req_md5)) != ngx_base64_encoded_length(16)) {
+			mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+			    "client md5 value is not properly b64 encoded, "
+			    "expected %d bytes, got %d",
+			    ngx_base64_encoded_length(16), ret);
+			return (B_FALSE);
+		}
+
+		dec.data = buf;
+		enc.data = (u_char *)req_md5;
+		enc.len = ngx_base64_encoded_length(16);
+		if (ngx_decode_base64(&dec, &enc) != NGX_OK) {
+			mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+			    "client md5 value is not properly b64 encoded, "
+			    "failed to decode b64 value");
+			return (B_FALSE);
+		}
+
+		mpcr->mpcr_req_md5 = req_md5;
+	}
+
+	if (strchr(account, '.') != NULL || strchr(account, '/') != NULL) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+		    "found illegal character, '.' or '/' in account name");
+		return (B_FALSE);
+	}
+
+	if (strchr(account, '.') != NULL || strchr(account, '/') != NULL) {
+		mpu_set_error(mpcr, NGX_HTTP_BAD_REQUEST, 0,
+		    "found illegal character, '.' or '/' in objid name");
+		return (B_FALSE);
+	}
+
+	if (!mpu_check_parts(mpcr, account, parts, nparts))
+		return (B_FALSE);
+
+	mpcr->mpcr_account = account;
+	mpcr->mpcr_objid = objid;
+	mpcr->mpcr_nbytes = nbytes;
+
+	ret = mpu_check_exists(mpcr);
+	if (ret == MPU_FAILURE)
+		return (B_FALSE);
+	if (ret == MPU_EALREADY)
+		goto cleanup;
+
+	/*
+	 * We'll validate the parts on the fly.
+	 */
+	bzero(&tmpfile, sizeof (tmpfile));
+	if (!mpu_alloc_tmpfile(mpcr, &tmpfile))
+		return (B_FALSE);
+
+	if ((ret = mpu_nvl_append_parts(mpcr, parts, nparts, &tmpfile)) !=
+	    MPU_SUCCESS) {
+		/*
+		 * While trying to append parts, we may have been unable to find
+		 * a part. That could be because there was a bad specification
+		 * or because there was just a race with something else that had
+		 * correctly constructed the file. In either case we always
+		 * unlink our temporary file.
+		 */
+		if (ngx_delete_file(tmpfile.name.data) == NGX_FILE_ERROR) {
+			VERIFY3S(errno, !=, EFAULT);
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, errno,
+			    "failed to remove temporary file %s after failing "
+			    "to append parts", tmpfile.name.data);
+		}
+
+		if (ret == MPU_EALREADY)
+			goto cleanup;
+		return (B_FALSE);
+	}
+
+	if (!mpu_verify_size(mpcr, &tmpfile)) {
+		if (ngx_delete_file(tmpfile.name.data) == NGX_FILE_ERROR) {
+			VERIFY3S(errno, !=, EFAULT);
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, errno,
+			    "failed to remove temporary file %s after size "
+			    "check failed", tmpfile.name.data);
+		}
+		return (B_FALSE);
+	}
+
+	ngx_md5_final(mpcr->mpcr_md5_buf, &mpcr->mpcr_md5);
+
+	if (!mpu_convert_md5(mpcr) || !mpu_verify_md5(mpcr)) {
+		if (ngx_delete_file(tmpfile.name.data) == NGX_FILE_ERROR) {
+			VERIFY3S(errno, !=, EFAULT);
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, errno,
+			    "failed to remove temporary file %s after md5 "
+			    "calc failed", tmpfile.name.data);
+		}
+		return (B_FALSE);
+	}
+
+	/*
+	 * This function guarantees that the temporary file is either renamed or
+	 * deleted.
+	 */
+	if (!mpu_rename(mpcr, &tmpfile))
+		return (B_FALSE);
+
+cleanup:
+	mpu_cleanup_parts(mpcr, parts, nparts);
+
+	return (B_TRUE);
+}
+
+/*
+ * This is called in the context of a given MPU request. Here we must do the
+ * heavy lifting of parsing the request and taking the actual actions.
+ */
+static void
+mpu_task_handler(void *arg, ngx_log_t *log)
+{
+	nvlist_t *nvl;
+	mpu_request_t *mpcr = arg;
+	char *buf;
+
+	buf = ngx_alloc(MPU_COMMIT_RW_SIZE, mpcr->mpcr_http->connection->log);
+	if (buf == NULL) {
+		mpcr->mpcr_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
+		return;
+	}
+
+	mpcr->mpcr_buf = buf;
+	mpcr->mpcr_buflen = MPU_COMMIT_RW_SIZE;
+	if (!mpu_readin_request(mpcr, &nvl)) {
+		ngx_free(buf);
+		mpcr->mpcr_buf = NULL;
+		mpcr->mpcr_buflen = 0;
+		return;
+	}
+
+	if (mpu_nvl_process(mpcr, nvl)) {
+		mpcr->mpcr_status = NGX_HTTP_NO_CONTENT;
+	}
+
+	nvlist_free(nvl);
+	ngx_free(buf);
+	mpcr->mpcr_buf = NULL;
+	mpcr->mpcr_buflen = 0;
+}
+
+/*
+ * This function executes on the main thread after we have finished executing
+ * our thread pool.
+ */
+static void
+mpu_post_thread(ngx_event_t *ev)
+{
+	int ret;
+	mpu_request_t *mpcr = ev->data;
+	ngx_http_request_t *r = mpcr->mpcr_http;
+
+
+	/*
+	 * We need to clean up some state here. We initially set that
+	 * we were blocked before we entered the thread pool. Now that we're
+	 * finally done with the thread pool, remove that indication. After
+	 * we've removed that indication, we need to call any write event
+	 * handler. That handler may do nothing or if we tried to finalize the
+	 * request while blocked, it will now take care of that action. Note,
+	 * it's important that we do this before we call back and try to output
+	 * data to nginx.
+	 */
+	r->main->blocked--;
+	r->write_event_handler(r);
+
+	r->headers_out.status = mpcr->mpcr_status;
+	if (mpcr->mpcr_status == NGX_HTTP_NO_CONTENT) {
+		ngx_table_elt_t *h;
+		h = ngx_list_push(&r->headers_out.headers);
+		if (h == NULL) {
+			/*
+			 * There's not much we can do at this point, just error
+			 * out.
+			 */
+			ret = NGX_HTTP_INTERNAL_SERVER_ERROR;
+			ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+			    "failed to allocate header for MD5");
+		} else {
+			h->hash = 1;
+			ngx_str_set(&h->key, "X-Joyent-Computed-Content-MD5");
+			h->value.data = (u_char *)mpcr->mpcr_md5_b64;
+			h->value.len = strlen(mpcr->mpcr_md5_b64);
+			r->headers_out.content_length_n = 0;
+			ret = mpcr->mpcr_status;
+		}
+	} else {
+		ngx_chain_t out;
+		ngx_buf_t *b = &mpcr->mpcr_ngx_buf;
+
+		ngx_str_set(&r->headers_out.content_type, mpu_content);
+		r->headers_out.content_type.len = strlen(mpu_content);
+		r->headers_out.content_length_n = strlen(mpcr->mpcr_error);
+
+		b->pos = (u_char *)mpcr->mpcr_error;
+		b->last = (u_char *)mpcr->mpcr_error +
+		    r->headers_out.content_length_n;
+		b->memory = 1;
+		b->last_buf = 1;
+
+		out.buf = b;
+		out.next = NULL;
+		ngx_http_send_header(r);
+		ret = ngx_http_output_filter(r, &out);
+	}
+
+	ngx_http_finalize_request(r, ret);
+	/*
+	 * We must tell the event loop to move forward with this connection
+	 * because we have run this in the thread pool and thus blocked some set
+	 * of events on it.
+	 */
+	ngx_http_run_posted_requests(r->connection);
+}
+
+/*
+ * This function executes on the event loop after the full body has been read by
+ * nginx into an appropriate file.
+ */
+static void
+mpu_post_body(ngx_http_request_t *r)
+{
+	ngx_thread_task_t *task;
+	mpu_request_t *mpcr;
+	mpu_loc_conf_t *conf;
+
+	if (r->request_body == NULL) {
+		ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0, "mpu body "
+		    "callback missing request body!");
+		ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+		return;
+	}
+
+	if (r->request_body->temp_file == NULL) {
+		ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0, "mpu body "
+		    "callback missing request temporary file!");
+		ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+		return;
+	}
+
+	conf = ngx_http_get_module_loc_conf(r, ngx_http_mpu_commit_module);
+	task = ngx_thread_task_alloc(r->pool, sizeof (mpu_request_t));
+	if (task == NULL) {
+		atomic_inc_64(&mpu_overloads);
+		ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0,
+		    "failed to allcoate MPU request structure");
+		ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+		return;
+	}
+
+	mpcr = task->ctx;
+	mpcr->mpcr_http = r;
+	mpcr->mpcr_task = task;
+	mpcr->mpcr_root = (const char *)conf->mcl_root.data;
+	mpcr->mpcr_status = NGX_HTTP_INTERNAL_SERVER_ERROR;
+	ngx_md5_init(&mpcr->mpcr_md5);
+
+	task->handler = mpu_task_handler;
+	task->event.data = mpcr;
+	task->event.handler = mpu_post_thread;
+
+	if (ngx_thread_task_post(conf->mcl_pool, task) != NGX_OK) {
+		ngx_log_error(NGX_LOG_CRIT, r->connection->log, 0,
+		    "failed to submit taskq entry, limit likely exceeded");
+		ngx_http_finalize_request(r, NGX_HTTP_INTERNAL_SERVER_ERROR);
+		return;
+	}
+
+	/*
+	 * Indicate that there is more going on in this request and that it
+	 * should not be cleaned up automatically. This is required because our
+	 * thread pool activity will be running asynchronously from this thread
+	 * and once we return saying we've handled it, it will try and finalize
+	 * the request.
+	 */
+	r->main->blocked++;
+
+}
+
+/*
+ * This is the primary function that is called by nginx to handle a request.
+ */
+static ngx_int_t
+mpu_handler(ngx_http_request_t *r)
+{
+	mpu_loc_conf_t *conf;
+
+	conf = ngx_http_get_module_loc_conf(r, ngx_http_mpu_commit_module);
+	if (conf->mcl_enabled != 1) {
+		return (NGX_DECLINED);
+	}
+
+	if (r->method != NGX_HTTP_POST) {
+		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+		    "Only \"POST\" requests allowed");
+		return (NGX_HTTP_NOT_ALLOWED);
+	}
+
+	r->request_body_in_file_only = 1;
+	r->request_body_in_persistent_file = 1;
+	r->request_body_in_clean_file = 1;
+	r->request_body_file_group_access = 1;
+	r->request_body_file_log_level = 0;
+
+	return (ngx_http_read_client_request_body(r,
+	    mpu_post_body));
+}
+
+static ngx_int_t
+mpu_init(ngx_conf_t *cf)
+{
+	ngx_http_handler_pt	*h;
+	ngx_http_core_main_conf_t  *cmcf;
+
+	cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
+
+	h = ngx_array_push(&cmcf->phases[NGX_HTTP_CONTENT_PHASE].handlers);
+	if (h == NULL) {
+		return (NGX_ERROR);
+	}
+
+	*h = mpu_handler;
+
+	return (NGX_OK);
+}
+
+static ngx_http_module_t ngx_http_mpu_commit_module_ctx = {
+	NULL,			/* preconfiguration */
+	mpu_init,		/* postconfiguration */
+
+	NULL,			/* create main configuration */
+	NULL,			/* init main configuration */
+
+	NULL,			/* create server configuration */
+	NULL,			/* merge server configuration */
+
+	mpu_create_loc_conf,	/* create location configuration */
+	mpu_merge_loc_conf	/* merge location configuration */
+
+};
+
+ngx_module_t ngx_http_mpu_commit_module = {
+	NGX_MODULE_V1,
+	&ngx_http_mpu_commit_module_ctx,  /* module context */
+	mpu_commands,			  /* module directives */
+	NGX_HTTP_MODULE,		  /* module type */
+	NULL,				  /* init master */
+	NULL,				  /* init module */
+	NULL,				  /* init process */
+	NULL,				  /* init thread */
+	NULL,				  /* exit thread */
+	NULL,				  /* exit process */
+	NULL,				  /* exit master */
+	NGX_MODULE_V1_PADDING
+};


### PR DESCRIPTION
This will bring the MPU module back to mantav2 nginx without rewriting git history.

After we do this we'll update manta-mako to point its nginx submodule to this commit.